### PR TITLE
[Feat] BaseEntity & ObjectMapper 수정, DB 테이블 모델링

### DIFF
--- a/src/main/java/woozlabs/echo/domain/member/entity/Member.java
+++ b/src/main/java/woozlabs/echo/domain/member/entity/Member.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import woozlabs.echo.global.common.entity.BaseEntity;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -18,8 +19,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
-public class Member {
+public class Member extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -36,13 +36,4 @@ public class Member {
     private String providerId;
 
     private String profileImage;
-
-    @OneToMany(mappedBy = "superAccount", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<SubAccount> subAccounts = new ArrayList<>();
-
-    @CreatedDate
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
 }

--- a/src/main/java/woozlabs/echo/domain/member/entity/SubAccount.java
+++ b/src/main/java/woozlabs/echo/domain/member/entity/SubAccount.java
@@ -10,8 +10,6 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -19,9 +17,10 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
-public class Member {
+public class SubAccount {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String email;
@@ -37,8 +36,9 @@ public class Member {
 
     private String profileImage;
 
-    @OneToMany(mappedBy = "superAccount", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<SubAccount> subAccounts = new ArrayList<>();
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "super_account_id")
+    private Member superAccount;
 
     @CreatedDate
     private LocalDateTime createdAt;

--- a/src/main/java/woozlabs/echo/domain/member/entity/SuperAccount.java
+++ b/src/main/java/woozlabs/echo/domain/member/entity/SuperAccount.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import woozlabs.echo.global.common.entity.BaseEntity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -15,7 +17,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class SubAccount extends BaseEntity {
+public class SuperAccount extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,7 +36,11 @@ public class SubAccount extends BaseEntity {
 
     private String profileImage;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "super_account_id")
-    private SuperAccount superAccount;
+    @OneToMany(mappedBy = "superAccount", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SubAccount> subAccounts = new ArrayList<>();
+
+    public void addSubAccount(SubAccount subAccount) {
+        subAccounts.add(subAccount);
+        subAccount.setSuperAccount(this);
+    }
 }

--- a/src/main/java/woozlabs/echo/global/common/entity/BaseEntity.java
+++ b/src/main/java/woozlabs/echo/global/common/entity/BaseEntity.java
@@ -1,0 +1,23 @@
+package woozlabs.echo.global.common.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/woozlabs/echo/global/config/ModuleConfig.java
+++ b/src/main/java/woozlabs/echo/global/config/ModuleConfig.java
@@ -1,0 +1,17 @@
+package woozlabs.echo.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ModuleConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
+    }
+}

--- a/src/main/java/woozlabs/echo/global/config/RestTemplateConfig.java
+++ b/src/main/java/woozlabs/echo/global/config/RestTemplateConfig.java
@@ -19,10 +19,6 @@ import java.sql.Connection;
 
 @Configuration
 public class RestTemplateConfig {
-    @Bean
-    public ObjectMapper objectMapper(){
-        return new ObjectMapper();
-    }
 
     @Bean
     public RestTemplate buildRestTemplate(RestTemplateBuilder restTemplateBuilder){


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- close #11 
- 확장성을 고려하여 생성일, 수정일을 BaseEntity에 담습니다.
- LocalDatetime이 담긴 엔티티를 반환 시 Jackson에서 오류가 발생하여 ObjectMapper 설정을 진행합니다.
- ModuleConfig에 ObjectMapper를 빈으로 등록함에 따라 RestTemplateConfig에서 중복 오류가 발생하여 RestTemplateConfig에서는 제거합니다.
- DB 테이블의 경우 현재 코드를 작성하다가 다시 전부 지운 상태입니다.
  - 모델링을 이렇게 한 이유는 처음에는 Sub_Account 테이블만 생성하였는데 첫 로그인이 이루어진 다음에 Member Table에 모두 저장되는 흐름에 따라서 Member Table에서는 모든 계정을 관리, 추후 서브 계정을 추가할 시 Super, Sub Account로 나누는게 어떨까해서 모델링 해놓았습니다.

## 완료한 기능 명세
- [x] BaseEntity 생성 및 적용
- [x] Super, Sub Account Table 모델링
- [x] ModuleConfig 생성

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

```java
objectMapper.registerModule(new JavaTimeModule());
```
Object Mapper를 위와 같이 JavaTimeModule을 추가하기 위해서 config로 등록하고 RestTemplate에서 제거해두었는데, 이래도 Gmail이 잘 불러오는지에 대한 확인이 필요합니다.

### 처리 완료

```text
추가적으로 Gmail 불러오기 과정에서는 헤더에 Bearer token을 실어서 보낼 필요가 없습니다.
-> 구글 측에서 발급한 액세스토큰을 파라미터로 넣고 있기 때문
```

<img width="810" alt="image" src="https://github.com/woozlabs/echo-be/assets/77393976/40d22fed-526b-4906-aa90-a7d9f6b9028d">

