### PR TITLE
[FEAT] Super, Sub Account DB 맵핑

### DIFF
--- a/src/main/java/woozlabs/echo/domain/member/entity/Member.java
+++ b/src/main/java/woozlabs/echo/domain/member/entity/Member.java
@@ -36,4 +36,7 @@ public class Member extends BaseEntity {
     private String providerId;
 
     private String profileImage;
+
+    @OneToOne(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private SuperAccount superAccount;
 }

--- a/src/main/java/woozlabs/echo/domain/member/entity/SubAccount.java
+++ b/src/main/java/woozlabs/echo/domain/member/entity/SubAccount.java
@@ -34,6 +34,12 @@ public class SubAccount extends BaseEntity {
 
     private String profileImage;
 
+    private String JwtToken;
+
+    private String googleAccessToken;
+
+    private String googleRefreshToken;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "super_account_id")
     private SuperAccount superAccount;

--- a/src/main/java/woozlabs/echo/domain/member/entity/SuperAccount.java
+++ b/src/main/java/woozlabs/echo/domain/member/entity/SuperAccount.java
@@ -36,6 +36,16 @@ public class SuperAccount extends BaseEntity {
 
     private String profileImage;
 
+    private String JwtToken;
+
+    private String googleAccessToken;
+
+    private String googleRefreshToken;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
     @OneToMany(mappedBy = "superAccount", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SubAccount> subAccounts = new ArrayList<>();
 

--- a/src/main/java/woozlabs/echo/domain/member/repository/SubAccountRepository.java
+++ b/src/main/java/woozlabs/echo/domain/member/repository/SubAccountRepository.java
@@ -1,0 +1,7 @@
+package woozlabs.echo.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import woozlabs.echo.domain.member.entity.SubAccount;
+
+public interface SubAccountRepository extends JpaRepository<SubAccount, Long> {
+}

--- a/src/main/java/woozlabs/echo/domain/member/repository/SuperAccountRepository.java
+++ b/src/main/java/woozlabs/echo/domain/member/repository/SuperAccountRepository.java
@@ -1,0 +1,9 @@
+package woozlabs.echo.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import woozlabs.echo.domain.member.entity.SuperAccount;
+
+public interface SuperAccountRepository extends JpaRepository<SuperAccount, Long> {
+
+    SuperAccount findByEmail(String email);
+}

--- a/src/main/java/woozlabs/echo/domain/member/service/CustomOAuth2UserService.java
+++ b/src/main/java/woozlabs/echo/domain/member/service/CustomOAuth2UserService.java
@@ -1,8 +1,12 @@
 package woozlabs.echo.domain.member.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -10,8 +14,13 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import woozlabs.echo.domain.member.entity.Member;
 import woozlabs.echo.domain.member.entity.Role;
+import woozlabs.echo.domain.member.entity.SubAccount;
+import woozlabs.echo.domain.member.entity.SuperAccount;
 import woozlabs.echo.domain.member.repository.MemberRepository;
+import woozlabs.echo.domain.member.repository.SubAccountRepository;
+import woozlabs.echo.domain.member.repository.SuperAccountRepository;
 import woozlabs.echo.global.security.GoogleOauthMemberDetails;
+import woozlabs.echo.global.security.provider.JwtProvider;
 
 import java.util.Map;
 import java.util.Optional;
@@ -22,11 +31,20 @@ import java.util.Optional;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final MemberRepository memberRepository;
+    private final SuperAccountRepository superAccountRepository;
+    private final SubAccountRepository subAccountRepository;
+    private final JwtProvider jwtProvider;
+    private final HttpServletRequest request;
+    private final HttpServletResponse response;
+
+    @Value("${jwt.access_token_expiration}")
+    private Long accessTokenExpiration;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
         String oauthClientName = userRequest.getClientRegistration().getClientName();
+        String googleAccessToken = userRequest.getAccessToken().getTokenValue();
 
         try {
             log.info("OAuth2 User Attributes: {}", new ObjectMapper().writeValueAsString(oAuth2User.getAttributes()));
@@ -37,10 +55,50 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         if (oauthClientName.equals("Google")) {
             Map<String, Object> attributes = oAuth2User.getAttributes();
             String providerId = attributes.get("sub").toString();
-            Member member = memberRepository.findByProviderAndProviderId("google", providerId);
-            if (member == null) {
-                member = createUserFromOAuth2User(oAuth2User, providerId);
+            String email = oAuth2User.getAttribute("email");
+            String name = oAuth2User.getAttribute("name");
+            String profileImage = oAuth2User.getAttribute("picture");
+
+            String superToken = getCookieValue(request, "superToken");
+            if (superToken == null || !jwtProvider.validateToken(superToken)) {
+                // 첫 번째 로그인인 경우 Super Account 등록
+                SuperAccount superAccount = superAccountRepository.findByEmail(email);
+                if (superAccount == null) {
+                    String superAccountJwtToken = jwtProvider.generateToken(email, accessTokenExpiration);
+                    superAccount = createSuperAccountFromOAuth2User(oAuth2User, providerId, googleAccessToken, superAccountJwtToken);
+                }
+
+                // Super 토큰 생성 후 쿠키에 저장
+                superToken = jwtProvider.generateToken(email, accessTokenExpiration);
+                Cookie superTokenCookie = new Cookie("superToken", superToken);
+                superTokenCookie.setHttpOnly(true);
+                superTokenCookie.setPath("/");
+                superTokenCookie.setMaxAge(-1); // 만료기한 무제한으로 설정 | 241618 ldhbenecia
+                response.addCookie(superTokenCookie);
+            } else {
+                String superEmail = jwtProvider.getUsernameFromToken(superToken);
+                Optional<Member> superMember = memberRepository.findByEmail(superEmail);
+                if (superMember.isPresent() && !superEmail.equals(email)) {
+                    String subAccountJwtToken = jwtProvider.generateToken(email, accessTokenExpiration);
+
+                    SubAccount subAccount = SubAccount.builder()
+                            .superAccount(superMember.get().getSuperAccount())
+                            .email(email)
+                            .name(name)
+                            .role(Role.ROLE_USER)
+                            .provider("google")
+                            .providerId(providerId)
+                            .profileImage(profileImage)
+                            .JwtToken(subAccountJwtToken)
+                            .googleAccessToken(googleAccessToken)
+                            .build();
+
+                    subAccountRepository.save(subAccount);
+                }
             }
+            Member member = memberRepository.findByEmail(email)
+                    .orElseGet(() -> createUserFromOAuth2User(oAuth2User, providerId));
+
             return new GoogleOauthMemberDetails(member, attributes);
         }
 
@@ -68,5 +126,52 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
             return memberRepository.save(member);
         }
+    }
+
+    private SuperAccount createSuperAccountFromOAuth2User(OAuth2User oAuth2User, String providerId, String googleAccessToken, String superAccountJwtToken) {
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        String email = attributes.get("email").toString();
+        String name = attributes.get("name").toString();
+        String profileImage = attributes.get("picture").toString();
+
+        Optional<Member> optionalMember = Optional.ofNullable(memberRepository.findByProviderAndProviderId("google", providerId));
+        Member member;
+        if (optionalMember.isPresent()) {
+            member = optionalMember.get();
+        } else {
+            member = Member.builder()
+                    .email(email)
+                    .name(name)
+                    .role(Role.ROLE_USER)
+                    .provider("google")
+                    .providerId(providerId)
+                    .profileImage(profileImage)
+                    .build();
+            memberRepository.save(member);
+        }
+
+        SuperAccount superAccount = SuperAccount.builder()
+                .email(email)
+                .name(name)
+                .role(Role.ROLE_USER)
+                .provider("google")
+                .providerId(providerId)
+                .profileImage(profileImage)
+                .googleAccessToken(googleAccessToken)
+                .JwtToken(superAccountJwtToken)
+                .member(member)
+                .build();
+        return superAccountRepository.save(superAccount);
+    }
+
+    private String getCookieValue(HttpServletRequest request, String cookieName) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (cookie.getName().equals(cookieName)) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/woozlabs/echo/global/security/provider/JwtProvider.java
+++ b/src/main/java/woozlabs/echo/global/security/provider/JwtProvider.java
@@ -30,12 +30,12 @@ public class JwtProvider {
 
     public String generateToken(String subject, Long accessTokenExpiration) {
         Date now = new Date();
-        Date expiration = new Date(now.getTime() + accessTokenExpiration);
+        //Date expiration = new Date(now.getTime() + accessTokenExpiration);
 
         return Jwts.builder()
                 .subject(subject)
                 .issuedAt(now)
-                .expiration(expiration) // 2 hours expiration
+                //.expiration(expiration) 만료기한 무제한으로 설정 | 240618 ldhbenecia
                 .signWith(key)
                 .compact();
     }


### PR DESCRIPTION
## 설명
- close #10 
- [연관관계 맵핑 노션 기록1](https://woozlabs.notion.site/240616-LDH-Multi-Google-Login-9eff688f2fc24f4fa20f67797634fbf4?pvs=4)
- [연관관계 맵핑 노션 기록2](https://woozlabs.notion.site/240616-LDH-Multi-Management-56b6770b0c3541b4be5df6fde6faaca9?pvs=4)

위의 기록을 잘 확인해주시기 바랍니다.
로직이 말로만 보면 상당히 복잡해서 이해하기 힘듭니다.

## 완료한 기능 명세
- [x] 처음 로그인하는 모든 계정은 Member 테이블에 추가
- [x] 첫 로그인 계정은 SuperAccount에 등록 후 Cookie에 슈퍼 계정이라는 표시
- [x] 두번째로 로그인 하는 계정은 쿠키에 담긴 토큰으로 연관관계 확인 후 DB에 SubAccount로 기록
- [x] JWT 발행 토큰 만료기한 무한으로 수정
- [x] 쿠키에 담아놓은 서브 토큰은 제거 후 DB에 기록

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기

### 처음 상태
<img width="919" alt="image" src="https://github.com/woozlabs/echo-be/assets/77393976/3dc920a1-d9fe-41b2-b2c4-f2d5890b154e">

### 첫 계정 로그인
- 쿠키에 슈퍼 토큰 삽입
<img width="1049" alt="image" src="https://github.com/woozlabs/echo-be/assets/77393976/bc510296-584f-41a8-978f-a059f600822a">

- 슈퍼 어카운트 삽입
<img width="1114" alt="image" src="https://github.com/woozlabs/echo-be/assets/77393976/c54e0a54-67ce-4308-a897-97651bb4fab0">

- 멤버 삽입
<img width="1085" alt="image" src="https://github.com/woozlabs/echo-be/assets/77393976/5bf491c3-5427-4ebe-8168-a308c319904c">

### 두 번째 추가 로그인

- 쿠키에 있는 슈퍼토큰 그대로
<img width="1065" alt="image" src="https://github.com/woozlabs/echo-be/assets/77393976/bd38f892-0b22-4aaf-ac05-cd32a4275923">

-  멤버 삽입
<img width="1047" alt="image" src="https://github.com/woozlabs/echo-be/assets/77393976/afd93886-aec8-4d6c-9792-32cadd7004d8">

- 서브 어카운트 삽입 (슈퍼 계정을 참조함)
<img width="1079" alt="image" src="https://github.com/woozlabs/echo-be/assets/77393976/ba7f7a32-0a01-4f54-ab65-4c9bd4979b03">



## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

