### PR TITLE
[FEAT & REFACTOR] Firebase idToken Verify 로직 구현 & AOP 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ application.yml
 
 ### env
 .env
+
+### firebase
+serviceAccountKey.json

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.3.1'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation group: 'com.google.firebase', name: 'firebase-admin', version: '9.3.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -18,6 +18,8 @@ steps:
       - 'gcr.io/echo-cloud-427211/echo-be:$COMMIT_SHA'
       - '--region'
       - 'asia-northeast3'
+      - '--set-secrets'
+      - 'GOOGLE_APPLICATION_CREDENTIALS=serviceAccountKey.json'
 
 images:
   - 'gcr.io/echo-cloud-427211/echo-be:$COMMIT_SHA'

--- a/src/main/java/woozlabs/echo/domain/member/controller/AuthController.java
+++ b/src/main/java/woozlabs/echo/domain/member/controller/AuthController.java
@@ -1,14 +1,15 @@
 package woozlabs.echo.domain.member.controller;
 
+import com.google.firebase.auth.FirebaseAuthException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import woozlabs.echo.domain.member.dto.AddAccountRequestDto;
 import woozlabs.echo.domain.member.dto.CreateAccountRequestDto;
 import woozlabs.echo.domain.member.service.AuthService;
+import woozlabs.echo.global.exception.CustomErrorException;
+import woozlabs.echo.global.exception.ErrorCode;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -21,5 +22,17 @@ public class AuthController {
     public ResponseEntity<Void> createAccount(@RequestBody CreateAccountRequestDto requestDto) {
         authService.createAccount(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/add-account")
+    public ResponseEntity<Void> addAccount(@RequestHeader("Authorization") String authorizationHeader,
+                                           @RequestBody AddAccountRequestDto requestDto) {
+        try {
+            String idToken = authorizationHeader.replace("Bearer ", "");
+            authService.addAccount(idToken, requestDto);
+            return ResponseEntity.status(HttpStatus.CREATED).build();
+        } catch (FirebaseAuthException e) {
+            throw new CustomErrorException(ErrorCode.NOT_VERIFY_ID_TOKEN);
+        }
     }
 }

--- a/src/main/java/woozlabs/echo/domain/member/controller/AuthController.java
+++ b/src/main/java/woozlabs/echo/domain/member/controller/AuthController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import woozlabs.echo.domain.member.dto.AddAccountRequestDto;
 import woozlabs.echo.domain.member.dto.CreateAccountRequestDto;
 import woozlabs.echo.domain.member.service.AuthService;
+import woozlabs.echo.global.aop.annotations.VerifyToken;
 import woozlabs.echo.global.exception.CustomErrorException;
 import woozlabs.echo.global.exception.ErrorCode;
 
@@ -18,9 +19,9 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @PostMapping("/create-account")
-    public ResponseEntity<Void> createAccount(@RequestBody CreateAccountRequestDto requestDto) {
-        authService.createAccount(requestDto);
+    @PostMapping("/sign-in")
+    public ResponseEntity<Void> signIn(@RequestBody CreateAccountRequestDto requestDto) {
+        authService.signIn(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
@@ -34,5 +35,11 @@ public class AuthController {
         } catch (FirebaseAuthException e) {
             throw new CustomErrorException(ErrorCode.NOT_VERIFY_ID_TOKEN);
         }
+    }
+
+    @GetMapping("/verify-token")
+    @VerifyToken
+    public ResponseEntity<String> testVerify() {
+        return ResponseEntity.ok("Token is valid");
     }
 }

--- a/src/main/java/woozlabs/echo/domain/member/dto/AddAccountRequestDto.java
+++ b/src/main/java/woozlabs/echo/domain/member/dto/AddAccountRequestDto.java
@@ -1,0 +1,16 @@
+package woozlabs.echo.domain.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AddAccountRequestDto {
+
+    private String uid;
+    private String displayName;
+    private String email;
+    private boolean emailVerified;
+    private String photoURL;
+    private String googleAccessToken;
+}

--- a/src/main/java/woozlabs/echo/domain/member/dto/CreateAccountRequestDto.java
+++ b/src/main/java/woozlabs/echo/domain/member/dto/CreateAccountRequestDto.java
@@ -13,5 +13,4 @@ public class CreateAccountRequestDto {
     private boolean emailVerified;
     private String photoURL;
     private String googleAccessToken;
-    private String superToken;
 }

--- a/src/main/java/woozlabs/echo/domain/member/entity/Member.java
+++ b/src/main/java/woozlabs/echo/domain/member/entity/Member.java
@@ -35,4 +35,7 @@ public class Member extends BaseEntity {
 
     @OneToOne(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private SuperAccount superAccount;
+
+    @OneToOne(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private SubAccount subAccount;
 }

--- a/src/main/java/woozlabs/echo/domain/member/entity/SubAccount.java
+++ b/src/main/java/woozlabs/echo/domain/member/entity/SubAccount.java
@@ -26,12 +26,14 @@ public class SubAccount extends BaseEntity {
     private String email;
     private boolean emailVerified;
     private String photoURL;
-
     private String googleAccessToken;
-    private String subToken;
 
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "super_account_id")

--- a/src/main/java/woozlabs/echo/domain/member/entity/SuperAccount.java
+++ b/src/main/java/woozlabs/echo/domain/member/entity/SuperAccount.java
@@ -28,11 +28,7 @@ public class SuperAccount extends BaseEntity {
     private String email;
     private boolean emailVerified;
     private String photoURL;
-
     private String googleAccessToken;
-
-    @Column(columnDefinition = "TEXT")
-    private String superToken;
 
     @Enumerated(EnumType.STRING)
     private Role role;

--- a/src/main/java/woozlabs/echo/domain/member/repository/SuperAccountRepository.java
+++ b/src/main/java/woozlabs/echo/domain/member/repository/SuperAccountRepository.java
@@ -3,7 +3,9 @@ package woozlabs.echo.domain.member.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import woozlabs.echo.domain.member.entity.SuperAccount;
 
+import java.util.Optional;
+
 public interface SuperAccountRepository extends JpaRepository<SuperAccount, Long> {
 
-    SuperAccount findByEmail(String email);
+    Optional<SuperAccount> findByUid(String uid);
 }

--- a/src/main/java/woozlabs/echo/domain/member/service/AuthService.java
+++ b/src/main/java/woozlabs/echo/domain/member/service/AuthService.java
@@ -56,9 +56,7 @@ public class AuthService {
 
     @Transactional
     public void addAccount(String idToken, AddAccountRequestDto requestDto) throws FirebaseAuthException {
-        FirebaseToken decodedToken = firebaseTokenVerifier.verifyToken(idToken);
-        String superAccountUid = decodedToken.getUid();
-
+        String superAccountUid = firebaseTokenVerifier.verifyTokenAndGetUid(idToken);
         SuperAccount superAccount = superAccountRepository.findByUid(superAccountUid)
                 .orElseThrow(() -> new CustomErrorException(ErrorCode.NOT_FOUND_SUPER_ACCOUNT));
 

--- a/src/main/java/woozlabs/echo/domain/member/service/AuthService.java
+++ b/src/main/java/woozlabs/echo/domain/member/service/AuthService.java
@@ -28,7 +28,7 @@ public class AuthService {
     private final FirebaseTokenVerifier firebaseTokenVerifier;
 
     @Transactional
-    public void createAccount(CreateAccountRequestDto requestDto) {
+    public void signIn(CreateAccountRequestDto requestDto) {
         Member member = Member.builder()
                 .uid(requestDto.getUid())
                 .displayName(requestDto.getDisplayName())

--- a/src/main/java/woozlabs/echo/domain/member/service/AuthService.java
+++ b/src/main/java/woozlabs/echo/domain/member/service/AuthService.java
@@ -1,15 +1,22 @@
 package woozlabs.echo.domain.member.service;
 
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import woozlabs.echo.domain.member.dto.AddAccountRequestDto;
 import woozlabs.echo.domain.member.dto.CreateAccountRequestDto;
 import woozlabs.echo.domain.member.entity.Member;
 import woozlabs.echo.domain.member.entity.Role;
+import woozlabs.echo.domain.member.entity.SubAccount;
 import woozlabs.echo.domain.member.entity.SuperAccount;
 import woozlabs.echo.domain.member.repository.MemberRepository;
 import woozlabs.echo.domain.member.repository.SubAccountRepository;
 import woozlabs.echo.domain.member.repository.SuperAccountRepository;
+import woozlabs.echo.global.exception.CustomErrorException;
+import woozlabs.echo.global.exception.ErrorCode;
+import woozlabs.echo.global.utils.FirebaseTokenVerifier;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +25,7 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final SuperAccountRepository superAccountRepository;
     private final SubAccountRepository subAccountRepository;
+    private final FirebaseTokenVerifier firebaseTokenVerifier;
 
     @Transactional
     public void createAccount(CreateAccountRequestDto requestDto) {
@@ -39,11 +47,44 @@ public class AuthService {
                 .emailVerified(requestDto.isEmailVerified())
                 .photoURL(requestDto.getPhotoURL())
                 .role(Role.ROLE_USER)
-                .superToken(requestDto.getSuperToken())
                 .googleAccessToken(requestDto.getGoogleAccessToken())
                 .member(member)
                 .build();
 
         superAccountRepository.save(superAccount);
+    }
+
+    @Transactional
+    public void addAccount(String idToken, AddAccountRequestDto requestDto) throws FirebaseAuthException {
+        FirebaseToken decodedToken = firebaseTokenVerifier.verifyToken(idToken);
+        String superAccountUid = decodedToken.getUid();
+
+        SuperAccount superAccount = superAccountRepository.findByUid(superAccountUid)
+                .orElseThrow(() -> new CustomErrorException(ErrorCode.NOT_FOUND_SUPER_ACCOUNT));
+
+        Member member = Member.builder()
+                .uid(requestDto.getUid())
+                .displayName(requestDto.getDisplayName())
+                .email(requestDto.getEmail())
+                .emailVerified(requestDto.isEmailVerified())
+                .photoURL(requestDto.getPhotoURL())
+                .role(Role.ROLE_USER)
+                .build();
+
+        memberRepository.save(member);
+
+        SubAccount subAccount = SubAccount.builder()
+                .uid(requestDto.getUid())
+                .displayName(requestDto.getDisplayName())
+                .email(requestDto.getEmail())
+                .emailVerified(requestDto.isEmailVerified())
+                .photoURL(requestDto.getPhotoURL())
+                .role(Role.ROLE_USER)
+                .googleAccessToken(requestDto.getGoogleAccessToken())
+                .member(member)
+                .superAccount(superAccount)
+                .build();
+
+        subAccountRepository.save(subAccount);
     }
 }

--- a/src/main/java/woozlabs/echo/global/aop/AuthVerifyAspect.java
+++ b/src/main/java/woozlabs/echo/global/aop/AuthVerifyAspect.java
@@ -1,0 +1,35 @@
+package woozlabs.echo.global.aop;
+
+import com.google.firebase.auth.FirebaseAuthException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import woozlabs.echo.global.exception.CustomErrorException;
+import woozlabs.echo.global.exception.ErrorCode;
+import woozlabs.echo.global.utils.FirebaseTokenVerifier;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class AuthVerifyAspect {
+
+    private final FirebaseTokenVerifier firebaseTokenVerifier;
+    private final HttpServletRequest request;
+
+    @Before("@annotation(woozlabs.echo.global.aop.annotations.VerifyToken)")
+    public void verifyToken() throws FirebaseAuthException {
+        String authorizationHeader = request.getHeader("Authorization");
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            throw new CustomErrorException(ErrorCode.NOT_FOUND_VERIFY_TOKEN);
+        }
+
+        String idToken = authorizationHeader.replace("Bearer ", "");
+        try {
+            firebaseTokenVerifier.verifyToken(idToken);
+        } catch (FirebaseAuthException e) {
+            throw new CustomErrorException(ErrorCode.NOT_VERIFY_ID_TOKEN);
+        }
+    }
+}

--- a/src/main/java/woozlabs/echo/global/aop/annotations/VerifyToken.java
+++ b/src/main/java/woozlabs/echo/global/aop/annotations/VerifyToken.java
@@ -1,0 +1,8 @@
+package woozlabs.echo.global.aop.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+public @interface VerifyToken {
+}

--- a/src/main/java/woozlabs/echo/global/config/FirebaseConfig.java
+++ b/src/main/java/woozlabs/echo/global/config/FirebaseConfig.java
@@ -1,0 +1,37 @@
+package woozlabs.echo.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import woozlabs.echo.global.exception.CustomErrorException;
+import woozlabs.echo.global.exception.ErrorCode;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Value("${firebase.sdk.path}")
+    private String firebaseSdkPath;
+
+    @PostConstruct
+    public void init() throws IOException {
+
+        try {
+            ClassPathResource resource = new ClassPathResource(firebaseSdkPath);
+            InputStream serviceAccount = resource.getInputStream();
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+            FirebaseApp.initializeApp(options);
+        } catch (FileNotFoundException e) {
+            throw new CustomErrorException(ErrorCode.NOT_FOUND_FIREBASE_SERVICE_ACCOUNT_KEY);
+        }
+    }
+}

--- a/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
+++ b/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     NOT_FOUND_MEMBER_ERROR_MESSAGE(404, "Not found: Member"),
     NOT_VERIFY_ID_TOKEN(401, "ID token is incorrect"),
     NOT_FOUND_SUPER_ACCOUNT(404, "Super account not found"),
+    NOT_FOUND_VERIFY_TOKEN(404, "Not found verifyToken"),
 
     // email
     REQUEST_GMAIL_USER_MESSAGES_GET_API_ERROR_MESSAGE(500, "Request gmail messages get one api");

--- a/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
+++ b/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
 
     // member
     NOT_FOUND_MEMBER_ERROR_MESSAGE(404, "Not found: Member"),
+    NOT_VERIFY_ID_TOKEN(401, "ID token is incorrect"),
+    NOT_FOUND_SUPER_ACCOUNT(404, "Super account not found"),
 
     // email
     REQUEST_GMAIL_USER_MESSAGES_GET_API_ERROR_MESSAGE(500, "Request gmail messages get one api");

--- a/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
+++ b/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
@@ -14,6 +14,9 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(500, "Server Error"),
     OBJECT_MAPPER_JSON_PARSING_ERROR_MESSAGE(500, "ObjectMapper Json Parsing Error"),
 
+    // firebase
+    NOT_FOUND_FIREBASE_SERVICE_ACCOUNT_KEY(404, "Not found Firebase SDK file"),
+
     // member
     NOT_FOUND_MEMBER_ERROR_MESSAGE(404, "Not found: Member"),
     NOT_VERIFY_ID_TOKEN(401, "ID token is incorrect"),

--- a/src/main/java/woozlabs/echo/global/utils/FirebaseTokenVerifier.java
+++ b/src/main/java/woozlabs/echo/global/utils/FirebaseTokenVerifier.java
@@ -1,0 +1,14 @@
+package woozlabs.echo.global.utils;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FirebaseTokenVerifier {
+
+    public FirebaseToken verifyToken(String idToken) throws FirebaseAuthException {
+        return FirebaseAuth.getInstance().verifyIdToken(idToken);
+    }
+}

--- a/src/main/java/woozlabs/echo/global/utils/FirebaseTokenVerifier.java
+++ b/src/main/java/woozlabs/echo/global/utils/FirebaseTokenVerifier.java
@@ -11,4 +11,9 @@ public class FirebaseTokenVerifier {
     public FirebaseToken verifyToken(String idToken) throws FirebaseAuthException {
         return FirebaseAuth.getInstance().verifyIdToken(idToken);
     }
+
+    public String verifyTokenAndGetUid(String idToken) throws FirebaseAuthException {
+        FirebaseToken decodedToken = verifyToken(idToken);
+        return decodedToken.getUid();
+    }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,6 +19,10 @@ spring:
       hibernate:
         format_sql: true
 
+firebase:
+  sdk:
+    path: serviceAccountKey.json
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
## 설명
- close #24 
- close #25
- add-account 로직을 구현합니다.
- 컨트롤러단에서 Header에 실려온 idToken을 받아서 디코딩합니다.
- 디코딩된 토큰으로 Super 계정의 UID를 얻을 수 있습니다.

### 야기되는 문제점
모든 컨트롤러단에서 Bearer를 파싱해서 검증해야합니다.
이러한 한 기능의 중복을 제거하기 위해 Spring AOP를 학습 후 적용합니다.

## 이 PR이 Merge될 시 직접 작성한 GCP 트리거도 동작합니다.
오류가 날 시 cloudbuild.yml을 수정해야합니다.
현재 예상 오류 중 하나는 Firebase 연동으로 serviceAccountKey를 등록해야하는데 원활히 될 지 모르겠습니다.
환경변수로 지정하는 코드를 cloudbuild.yml에 추가해놓았습니다.

## 완료한 기능 명세
- [x] Verify Token으로 uid 추출
- [x] 해당 슈퍼 계정의 uid를 통해 슈퍼 계정에서 해당 uid를 찾아 sub 계정과 super 계정을 DB에서 연관짓습니다.
- [x] 전역 에러 예외 코드 추가 및 처리
- [x] Spring AOP 적용
- [x] Test 성공
- [x] Next.js HomePage앱에 헤더에 토큰 실는 코드 추가
- [x] create-account -> sign-in으로 변경

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기
<img width="803" alt="image" src="https://github.com/woozlabs/echo-be/assets/77393976/56636d60-599b-4c63-8331-b2890e33aa2b">

<img width="590" alt="image" src="https://github.com/woozlabs/echo-be/assets/77393976/972e0713-498b-46c7-8af4-a3245edd813f">

### 토큰에 e빼서 틀린거 보냈을 때
<img width="790" alt="image" src="https://github.com/woozlabs/echo-be/assets/77393976/abda531d-e802-4f86-9e7d-024182b865a9">

### 토큰 없을 때
<img width="824" alt="image" src="https://github.com/woozlabs/echo-be/assets/77393976/a028030e-252f-409d-88d7-e91a1436b8b5">


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

아직 테스트는 해보지 못하였습니다.
사용해볼만한 API가 마땅치 않음 -> 테스트 API 생성 필요
클라이언트 코드 부분 수정 안됨
-> 완료
