### PR TITLE
[CHORE] Build 시간 단축을 위한 세팅

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+target/
+build/
+.idea/
+.git
+.gitignore
+README.md

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,7 @@
+# Ignore compiled binaries and build artifacts
+*.jar
+.git
+/dist
+
+# Ignore local development dependencies
+vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY application-prod.yml /app/src/main/resources/application-prod.yml
 RUN chmod +x ./gradlew
 RUN ./gradlew clean build -x test
 
-FROM openjdk:17
+FROM openjdk:17-jdk-alpine
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
 EXPOSE 8080

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -15,31 +15,64 @@ steps:
       - |
         gcloud secrets versions access latest --secret="application-prod" > application-prod.yml
 
-  # Build the container image
+  # Pull the cached image if it exists
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', 'asia-northeast3-docker.pkg.dev/echo-cloud-427211/cloud-run-source-deploy/echo-be/echo-be:$COMMIT_SHA', '.']
+    entrypoint: 'bash'
+    args: [
+      '-c',
+      'docker pull asia-northeast3-docker.pkg.dev/echo-cloud-427211/cloud-run-source-deploy/echo-be/echo-be:$COMMIT_SHA || exit 0'
+    ]
+
+  # Build the container image with caching
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [
+      'build',
+      '-t', 'asia-northeast3-docker.pkg.dev/echo-cloud-427211/cloud-run-source-deploy/echo-be/echo-be:$COMMIT_SHA',
+      '--cache-from', 'asia-northeast3-docker.pkg.dev/echo-cloud-427211/cloud-run-source-deploy/echo-be/echo-be:$COMMIT_SHA',
+      '.'
+    ]
     dir: './'
 
   # Push the container image to Container Registry
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', 'asia-northeast3-docker.pkg.dev/echo-cloud-427211/cloud-run-source-deploy/echo-be/echo-be:$COMMIT_SHA']
+    args: [
+      'push',
+      'asia-northeast3-docker.pkg.dev/echo-cloud-427211/cloud-run-source-deploy/echo-be/echo-be:$COMMIT_SHA'
+    ]
+
+  # Tag the latest image for cache purposes
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [
+      'tag',
+      'asia-northeast3-docker.pkg.dev/echo-cloud-427211/cloud-run-source-deploy/echo-be/echo-be:$COMMIT_SHA',
+      'asia-northeast3-docker.pkg.dev/echo-cloud-427211/cloud-run-source-deploy/echo-be/echo-be:latest'
+    ]
+
+  # Push the latest tagged image to Container Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [
+      'push',
+      'asia-northeast3-docker.pkg.dev/echo-cloud-427211/cloud-run-source-deploy/echo-be/echo-be:latest'
+    ]
 
   # Deploy container image to Cloud Run
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'gcloud'
-    args:
-      - 'run'
-      - 'deploy'
-      - 'echo-be'
-      - '--platform=managed'
-      - '--image'
-      - 'asia-northeast3-docker.pkg.dev/echo-cloud-427211/cloud-run-source-deploy/echo-be/echo-be:$COMMIT_SHA'
-      - '--region'
-      - 'asia-northeast3'
-      - '--allow-unauthenticated'
+    args: [
+      'run',
+      'deploy',
+      'echo-be',
+      '--platform=managed',
+      '--image',
+      'asia-northeast3-docker.pkg.dev/echo-cloud-427211/cloud-run-source-deploy/echo-be/echo-be:$COMMIT_SHA',
+      '--region',
+      'asia-northeast3',
+      '--allow-unauthenticated'
+    ]
 
 images:
   - 'asia-northeast3-docker.pkg.dev/echo-cloud-427211/cloud-run-source-deploy/echo-be/echo-be:$COMMIT_SHA'
+  - 'asia-northeast3-docker.pkg.dev/echo-cloud-427211/cloud-run-source-deploy/echo-be/echo-be:latest'
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## 설명
- close #41 
- 평균적으로 빌드 한번 당 3분 30초가 넘는 시간이 걸려서 확인하는데 많은 시간을 소모하였습니다.
- 빌드 시간을 단축합니다.
- .gcloudignore 파일은 Google Cloud Build에서 파일 업로드를 제어하는 데 사용됩니다.
- .dockerignore 파일은 도커 빌드 컨텍스트에서 불필요한 파일이나 디렉터리를 제외하도록 설정합니다.

## 완료한 기능 명세
- [x] cloudbuild.yaml 캐싱 추가 
- [x] ignore 파일 추가

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

