### PR TITLE
[FEAT] Token Scheduler 구현

### DIFF
--- a/src/main/java/woozlabs/echo/EchoApplication.java
+++ b/src/main/java/woozlabs/echo/EchoApplication.java
@@ -3,9 +3,11 @@ package woozlabs.echo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@EnableScheduling
 @EnableJpaAuditing
+@SpringBootApplication
 public class EchoApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(EchoApplication.class, args);

--- a/src/main/java/woozlabs/echo/domain/member/entity/Member.java
+++ b/src/main/java/woozlabs/echo/domain/member/entity/Member.java
@@ -1,14 +1,15 @@
 package woozlabs.echo.domain.member.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
 import woozlabs.echo.global.common.entity.BaseEntity;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -24,6 +25,7 @@ public class Member extends BaseEntity {
     private String profileImageUrl;
     private String accessToken;
     private String refreshToken;
+    private LocalDateTime accessTokenFetchedAt;
 
     @Enumerated(EnumType.STRING)
     private Role role;

--- a/src/main/java/woozlabs/echo/domain/member/entity/SubAccount.java
+++ b/src/main/java/woozlabs/echo/domain/member/entity/SubAccount.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import woozlabs.echo.global.common.entity.BaseEntity;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Setter
@@ -24,6 +26,7 @@ public class SubAccount extends BaseEntity {
     private String profileImageUrl;
     private String accessToken;
     private String refreshToken;
+    private LocalDateTime accessTokenFetchedAt;
 
     @Enumerated(EnumType.STRING)
     private Role role;

--- a/src/main/java/woozlabs/echo/domain/member/entity/SuperAccount.java
+++ b/src/main/java/woozlabs/echo/domain/member/entity/SuperAccount.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import woozlabs.echo.global.common.entity.BaseEntity;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,6 +28,7 @@ public class SuperAccount extends BaseEntity {
     private String profileImageUrl;
     private String accessToken;
     private String refreshToken;
+    private LocalDateTime accessTokenFetchedAt;
 
     @Enumerated(EnumType.STRING)
     private Role role;

--- a/src/main/java/woozlabs/echo/domain/member/service/TokenSchedulerService.java
+++ b/src/main/java/woozlabs/echo/domain/member/service/TokenSchedulerService.java
@@ -41,11 +41,12 @@ public class TokenSchedulerService {
             SuperAccount superAccount = member.getSuperAccount();
             if (superAccount != null && shouldRefreshToken(superAccount.getAccessTokenFetchedAt())) {
                 refreshToken(superAccount);
-            }
 
-            for (SubAccount subAccount : member.getSubAccount()) {
-                if (shouldRefreshToken(subAccount.getAccessTokenFetchedAt())) {
-                    refreshToken(subAccount);
+                List<SubAccount> subAccounts = superAccount.getSubAccounts();
+                for (SubAccount subAccount : subAccounts) {
+                    if (shouldRefreshToken(subAccount.getAccessTokenFetchedAt())) {
+                        refreshToken(subAccount);
+                    }
                 }
             }
         }

--- a/src/main/java/woozlabs/echo/domain/member/service/TokenSchedulerService.java
+++ b/src/main/java/woozlabs/echo/domain/member/service/TokenSchedulerService.java
@@ -1,0 +1,105 @@
+package woozlabs.echo.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import woozlabs.echo.domain.member.entity.Member;
+import woozlabs.echo.domain.member.entity.SubAccount;
+import woozlabs.echo.domain.member.entity.SuperAccount;
+import woozlabs.echo.domain.member.repository.MemberRepository;
+import woozlabs.echo.domain.member.repository.SubAccountRepository;
+import woozlabs.echo.domain.member.repository.SuperAccountRepository;
+import woozlabs.echo.global.exception.CustomErrorException;
+import woozlabs.echo.global.exception.ErrorCode;
+import woozlabs.echo.global.utils.GoogleOAuthUtils;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TokenSchedulerService {
+
+    private final MemberRepository memberRepository;
+    private final SuperAccountRepository superAccountRepository;
+    private final SubAccountRepository subAccountRepository;
+    private final GoogleOAuthUtils googleOAuthUtils;
+
+    @Scheduled(fixedRate = 60000)
+    @Transactional
+    public void checkAndRefreshTokens() {
+        List<Member> members = memberRepository.findAll();
+        for (Member member : members) {
+            if (shouldRefreshToken(member.getAccessTokenFetchedAt())) {
+                refreshToken(member);
+            }
+
+            SuperAccount superAccount = member.getSuperAccount();
+            if (superAccount != null && shouldRefreshToken(superAccount.getAccessTokenFetchedAt())) {
+                refreshToken(superAccount);
+            }
+
+            for (SubAccount subAccount : member.getSubAccount()) {
+                if (shouldRefreshToken(subAccount.getAccessTokenFetchedAt())) {
+                    refreshToken(subAccount);
+                }
+            }
+        }
+    }
+
+    private boolean shouldRefreshToken(LocalDateTime tokenFetchedAt) {
+        if (tokenFetchedAt == null) {
+            return false;
+        }
+        LocalDateTime now = LocalDateTime.now();
+        long minutesElapsed = ChronoUnit.MINUTES.between(tokenFetchedAt, now);
+
+        return minutesElapsed >= 57;
+    }
+
+    public void refreshToken(Member member) {
+        try {
+            Map<String, String> newtokens = googleOAuthUtils.refreshAccessToken(member.getRefreshToken());
+            String newAccessToken = newtokens.get("access_token");
+
+            member.setAccessToken(newAccessToken);
+            member.setAccessTokenFetchedAt(LocalDateTime.now());
+            memberRepository.save(member);
+        } catch (Exception e) {
+            throw new CustomErrorException(ErrorCode.FAILED_TO_REFRESH_GOOGLE_TOKEN);
+        }
+    }
+
+    private void refreshToken(SuperAccount superAccount) {
+        try {
+            Map<String, String> newTokens = googleOAuthUtils.refreshAccessToken(superAccount.getRefreshToken());
+            String newAccessToken = newTokens.get("access_token");
+
+            superAccount.setAccessToken(newAccessToken);
+            superAccount.setAccessTokenFetchedAt(LocalDateTime.now());
+
+            superAccountRepository.save(superAccount);
+        } catch (Exception e) {
+            throw new CustomErrorException(ErrorCode.FAILED_TO_REFRESH_GOOGLE_TOKEN);
+        }
+    }
+
+    private void refreshToken(SubAccount subAccount) {
+        try {
+            Map<String, String> newTokens = googleOAuthUtils.refreshAccessToken(subAccount.getRefreshToken());
+            String newAccessToken = newTokens.get("access_token");
+
+            subAccount.setAccessToken(newAccessToken);
+            subAccount.setAccessTokenFetchedAt(LocalDateTime.now());
+
+            subAccountRepository.save(subAccount);
+        } catch (Exception e) {
+            throw new CustomErrorException(ErrorCode.FAILED_TO_REFRESH_GOOGLE_TOKEN);
+        }
+    }
+
+}

--- a/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
+++ b/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     FAILED_TO_FETCH_GOOGLE_USER_INFO(500, "Failed to fetch Google user info"),
     FAILED_TO_FETCH_GOOGLE_USER_INFO_UTILS(500, "Failed to fetch Google user info (GoogleOAuthUtils)"),
     FAILED_TO_REDIRECT_GOOGLE_USER_INFO(500, "Failed to redirect Google user info"),
+    FAILED_TO_REFRESH_GOOGLE_TOKEN(500, "Failed to refresh google token"),
 
     // token
     NOT_FOUND_ACCESS_TOKEN(404, "Not found: Access Token"),


### PR DESCRIPTION
## 설명
- close #14 
- RefreshToken을 가져오는 과정을 거쳤으니 이를 사용해서 액세스 토큰을 관리합니다.
- Spring Scheduler를 통해 1분마다 스케줄링을 거칩니다.
  - 모든 유저의 액세스 토큰 만료기한을 확인하고 3분 정도가 남았을 경우 새 액세스토큰으로 교체합니다.

## 완료한 기능 명세
- [x] Spring Scheduler 설정
- [x] Entity에 마지막 액세스 토큰 발행 날짜 레코드를 추가하여 기록
- [x] Scheduler 구현
- [x] 3분 이내가 남았을 경우 스케줄링을 통해 감지하여 해당 토큰은 새 발행

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기

[스크린샷 및 짧은 과정 기록](https://ldhbenecia.notion.site/SpringBoot-Scheduler-93ffe9b1e61f4800807a13069b7f6786?pvs=4)

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

