### PR TITLE
[Feat]: 이메일 전송 기능 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.3.1'
 	implementation group: 'com.google.firebase', name: 'firebase-admin', version: '9.3.0'
+	implementation group: 'javax.mail', name: 'mail', version: '1.4'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/woozlabs/echo/domain/gmail/controller/GmailController.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/controller/GmailController.java
@@ -93,9 +93,10 @@ public class GmailController {
 
 
     @PostMapping("/api/v1/gmail/messages/send")
-    public ResponseEntity<ResponseDto> sendMessage(@RequestBody GmailMessageSendRequest request){
+    public ResponseEntity<ResponseDto> sendMessage(@RequestParam("accessToken") String accessToken, @RequestBody GmailMessageSendRequest request){
         log.info("Request to send message");
         try {
+            GmailMessageSendResponse response = gmailService.sendUserEmailMessage(accessToken, request);
             return new ResponseEntity<>(HttpStatus.CREATED);
         }catch (Exception e){
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);

--- a/src/main/java/woozlabs/echo/domain/gmail/controller/GmailController.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/controller/GmailController.java
@@ -101,7 +101,7 @@ public class GmailController {
                                                    @RequestPart("toEmailAddress") String toEmailAddress,
                                                    @RequestPart("subject") String subject,
                                                    @RequestPart("bodyText") String bodyText,
-                                                   @RequestPart("files") List<MultipartFile> files){
+                                                   @RequestPart(value = "files", required = false) List<MultipartFile> files){
         log.info("Request to send message");
         try {
             GmailMessageSendRequest request = new GmailMessageSendRequest();

--- a/src/main/java/woozlabs/echo/domain/gmail/controller/GmailController.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/controller/GmailController.java
@@ -15,10 +15,11 @@ import woozlabs.echo.global.dto.ResponseDto;
 public class GmailController {
     private final GmailService gmailService;
 
+    // threads
     @GetMapping("/api/v1/gmail/threads/inbox")
     public ResponseEntity<ResponseDto> getInboxThreads(@RequestParam("accessToken") String accessToken,
-                                                  @RequestParam(value = "pageToken", required = false) String pageToken,
-                                                  @RequestParam(value = "category", required = false, defaultValue = "category:primary") String category){
+                                                       @RequestParam(value = "pageToken", required = false) String pageToken,
+                                                       @RequestParam(value = "category", required = false, defaultValue = "category:primary") String category){
         log.info("Request to get threads");
         try {
             GmailThreadListResponse response = gmailService.getUserEmailThreads(accessToken, pageToken, category);
@@ -76,6 +77,20 @@ public class GmailController {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
     }
+
+    // messages
+    @GetMapping("/api/v1/gmail/messages/{messageid}/attachments/{id}")
+    public ResponseEntity<ResponseDto> getAttachment(@RequestParam("accessToken") String accessToken,
+                                                     @PathVariable("messageid") String messageId, @PathVariable("id") String id){
+        log.info("Request to get attachment in message");
+        try {
+            GmailMessageAttachmentResponse response = gmailService.getAttachment(accessToken, messageId, id);
+            return new ResponseEntity<>(response, HttpStatus.OK);
+        }catch (Exception e){
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+    }
+
 
     @PostMapping("/api/v1/gmail/messages/send")
     public ResponseEntity<ResponseDto> sendMessage(@RequestBody GmailMessageSendRequest request){

--- a/src/main/java/woozlabs/echo/domain/gmail/controller/GmailController.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/controller/GmailController.java
@@ -97,7 +97,7 @@ public class GmailController {
         log.info("Request to send message");
         try {
             GmailMessageSendResponse response = gmailService.sendUserEmailMessage(accessToken, request);
-            return new ResponseEntity<>(HttpStatus.CREATED);
+            return new ResponseEntity<>(response, HttpStatus.CREATED);
         }catch (Exception e){
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }

--- a/src/main/java/woozlabs/echo/domain/gmail/controller/GmailController.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/controller/GmailController.java
@@ -3,11 +3,15 @@ package woozlabs.echo.domain.gmail.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import woozlabs.echo.domain.gmail.dto.*;
 import woozlabs.echo.domain.gmail.service.GmailService;
 import woozlabs.echo.global.dto.ResponseDto;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -92,10 +96,19 @@ public class GmailController {
     }
 
 
-    @PostMapping("/api/v1/gmail/messages/send")
-    public ResponseEntity<ResponseDto> sendMessage(@RequestParam("accessToken") String accessToken, @RequestBody GmailMessageSendRequest request){
+    @PostMapping(value = "/api/v1/gmail/messages/send", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ResponseDto> sendMessage(@RequestParam("accessToken") String accessToken,
+                                                   @RequestPart("toEmailAddress") String toEmailAddress,
+                                                   @RequestPart("subject") String subject,
+                                                   @RequestPart("bodyText") String bodyText,
+                                                   @RequestPart("files") List<MultipartFile> files){
         log.info("Request to send message");
         try {
+            GmailMessageSendRequest request = new GmailMessageSendRequest();
+            request.setToEmailAddress(toEmailAddress);
+            request.setSubject(subject);
+            request.setBodyText(bodyText);
+            request.setFiles(files);
             GmailMessageSendResponse response = gmailService.sendUserEmailMessage(accessToken, request);
             return new ResponseEntity<>(response, HttpStatus.CREATED);
         }catch (Exception e){

--- a/src/main/java/woozlabs/echo/domain/gmail/dto/GmailMessageAttachmentResponse.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/dto/GmailMessageAttachmentResponse.java
@@ -1,0 +1,14 @@
+package woozlabs.echo.domain.gmail.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import woozlabs.echo.global.dto.ResponseDto;
+
+@Getter
+@Builder
+public class GmailMessageAttachmentResponse implements ResponseDto {
+    private String attachmentId;
+    private int size;
+    private String data;
+}

--- a/src/main/java/woozlabs/echo/domain/gmail/dto/GmailMessageSendRequest.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/dto/GmailMessageSendRequest.java
@@ -1,6 +1,9 @@
 package woozlabs.echo.domain.gmail.dto;
 
 import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Data
 public class GmailMessageSendRequest {
@@ -8,4 +11,5 @@ public class GmailMessageSendRequest {
     private String fromEmailAddress;
     private String subject;
     private String bodyText;
+    private List<MultipartFile> files;
 }

--- a/src/main/java/woozlabs/echo/domain/gmail/dto/GmailMessageSendResponse.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/dto/GmailMessageSendResponse.java
@@ -4,8 +4,13 @@ import lombok.Builder;
 import lombok.Getter;
 import woozlabs.echo.global.dto.ResponseDto;
 
+import java.util.List;
+
 @Getter
 @Builder
 public class GmailMessageSendResponse implements ResponseDto {
     private String id;
+    private String threadId;
+    private List<String> labelsId;
+    private String snippet;
 }

--- a/src/main/java/woozlabs/echo/domain/gmail/service/GmailService.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/service/GmailService.java
@@ -113,6 +113,9 @@ public class GmailService {
 
     public GmailMessageSendResponse sendUserEmailMessage(String accessToken, GmailMessageSendRequest request) throws Exception{
         Gmail gmailService = createGmailService(accessToken);
+        Profile profile = gmailService.users().getProfile(USER_ID).execute();
+        String fromEmailAddress = profile.getEmailAddress();
+        request.setFromEmailAddress(fromEmailAddress);
         MimeMessage mimeMessage = createEmail(request);
         Message message = createMessage(mimeMessage);
         Message responseMessage = gmailService.users().messages().send(USER_ID, message).execute();

--- a/src/main/java/woozlabs/echo/domain/gmail/service/GmailService.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/service/GmailService.java
@@ -93,6 +93,18 @@ public class GmailService {
                 .build();
     }
 
+    public GmailMessageAttachmentResponse getAttachment(String accessToken, String messageId, String id) throws Exception{
+        Gmail gmailService = createGmailService(accessToken);
+        MessagePartBody attachment = gmailService.users().messages()
+                .attachments()
+                .get(USER_ID, messageId, id)
+                .execute();
+        return GmailMessageAttachmentResponse.builder()
+                .attachmentId(attachment.getAttachmentId())
+                .size(attachment.getSize())
+                .data(attachment.getData()).build();
+    }
+
     public void sendUserEmailMessage(String accessToken) throws Exception{
         Gmail gmailService = createGmailService(accessToken);
         //gmailService.users().messages().send(USER_ID);

--- a/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
+++ b/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
@@ -35,7 +35,8 @@ public enum ErrorCode {
 
 
     // email
-    REQUEST_GMAIL_USER_THREADS_GET_API_ERROR_MESSAGE(500, "Request gmail threads get one api");
+    REQUEST_GMAIL_USER_THREADS_GET_API_ERROR_MESSAGE(500, "failed get gmail threads api"),
+    REQUEST_GMAIL_USER_MESSAGES_SEND_API_ERROR_MESSAGE(400, "failed send gmail messages api");
 
 
     private final int status;


### PR DESCRIPTION
## 설명
- 이메일 전송 기능 구현 완료
- 이메일 전송 요청은 /api/v1/gmail/messages/send로 요청한다.
- 첨부파일이 있을 수 있으므로 JSON 형태가 아닌 form-data 형태로 요청한다.
- form-data에 포함되어야 할 데이터는 subject, toEmailAddress, bodyText, files(* Optional)이다.

## 완료한 기능 명세
- [x] 이메일 전송 기능 구현 완료
- [x] 첨부 파일 조회 기능 구현 완료

### 스크린샷
<img width="1005" alt="image" src="https://github.com/woozlabs/echo-be/assets/67581495/c78b9001-dec1-413f-bcb6-8c8784b9ba0b">
<img width="1182" alt="image" src="https://github.com/woozlabs/echo-be/assets/67581495/5aa59fc0-883f-42a0-b0c2-357fa45a24c9">
