### PR TITLE
[Feat]: Firebase Token 인증을 위한 인터셉터 구현

### DIFF
--- a/src/main/java/woozlabs/echo/domain/gmail/controller/GmailController.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/controller/GmailController.java
@@ -1,5 +1,6 @@
 package woozlabs.echo.domain.gmail.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import woozlabs.echo.domain.gmail.dto.*;
 import woozlabs.echo.domain.gmail.service.GmailService;
+import woozlabs.echo.global.constant.GlobalConstant;
 import woozlabs.echo.global.dto.ResponseDto;
 
 import java.util.List;
@@ -21,12 +23,13 @@ public class GmailController {
 
     // threads
     @GetMapping("/api/v1/gmail/threads/inbox")
-    public ResponseEntity<ResponseDto> getInboxThreads(@RequestParam("accessToken") String accessToken,
+    public ResponseEntity<ResponseDto> getInboxThreads(HttpServletRequest httpServletRequest,
                                                        @RequestParam(value = "pageToken", required = false) String pageToken,
                                                        @RequestParam(value = "category", required = false, defaultValue = "category:primary") String category){
         log.info("Request to get threads");
         try {
-            GmailThreadListResponse response = gmailService.getUserEmailThreads(accessToken, pageToken, category);
+            String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
+            GmailThreadListResponse response = gmailService.getUserEmailThreads(uid, pageToken, category);
             return new ResponseEntity<>(response, HttpStatus.OK);
         }catch (Exception e){
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
@@ -37,12 +40,13 @@ public class GmailController {
     public ResponseEntity<ResponseDto> searchThreads(@RequestParam(value = "from", required = false) String from,
                                                      @RequestParam(value = "to", required = false) String to,
                                                      @RequestParam(value = "subject", required = false) String subject,
-                                                     @RequestParam(value = "q", required = false) String query, @RequestParam("accessToken") String accessToken){
+                                                     @RequestParam(value = "q", required = false) String query, HttpServletRequest httpServletRequest){
         log.info("Request to search threads");
         try {
+            String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
             GmailSearchParams params = GmailSearchParams.builder()
                     .from(from).to(to).subject(subject).query(query).build();
-            GmailThreadListSearchResponse response = gmailService.searchUserEmailThreads(accessToken, params);
+            GmailThreadListSearchResponse response = gmailService.searchUserEmailThreads(uid, params);
             return new ResponseEntity<>(response, HttpStatus.OK);
         }catch (Exception e){
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
@@ -50,10 +54,11 @@ public class GmailController {
     }
 
     @GetMapping("/api/v1/gmail/threads/{id}")
-    public ResponseEntity<ResponseDto> getThread(@RequestParam("accessToken") String accessToken, @PathVariable("id") String id){
+    public ResponseEntity<ResponseDto> getThread(HttpServletRequest httpServletRequest, @PathVariable("id") String id){
         log.info("Request to get thread");
         try{
-            GmailThreadGetResponse response = gmailService.getUserEmailThread(accessToken, id);
+            String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
+            GmailThreadGetResponse response = gmailService.getUserEmailThread(uid, id);
             return new ResponseEntity<>(response, HttpStatus.OK);
         }catch (Exception e){
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
@@ -61,10 +66,11 @@ public class GmailController {
     }
 
     @DeleteMapping("/api/v1/gmail/threads/{id}/trash")
-    public ResponseEntity<ResponseDto> trashThread(@RequestParam("accessToken") String accessToken, @PathVariable("id") String id){
+    public ResponseEntity<ResponseDto> trashThread(HttpServletRequest httpServletRequest, @PathVariable("id") String id){
         log.info("Request to trash thread");
         try {
-            GmailThreadTrashResponse response = gmailService.trashUserEmailThread(accessToken, id);
+            String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
+            GmailThreadTrashResponse response = gmailService.trashUserEmailThread(uid, id);
             return new ResponseEntity<>(response, HttpStatus.NO_CONTENT);
         }catch (Exception e){
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
@@ -72,11 +78,12 @@ public class GmailController {
     }
 
     @DeleteMapping("/api/v1/gmail/threads/{id}")
-    public ResponseEntity<ResponseDto> deleteThread(@RequestParam("accessToken") String accessToken, @PathVariable("id") String id){
+    public ResponseEntity<ResponseDto> deleteThread(HttpServletRequest httpServletRequest, @PathVariable("id") String id){
         log.info("Request to delete thread");
         try {
-            GmailThreadDeleteResponse response = gmailService.deleteUserEmailThread(accessToken, id);
-            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+            String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
+            GmailThreadDeleteResponse response = gmailService.deleteUserEmailThread(uid, id);
+            return new ResponseEntity<>(response, HttpStatus.NO_CONTENT);
         }catch (Exception e){
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
@@ -84,11 +91,12 @@ public class GmailController {
 
     // messages
     @GetMapping("/api/v1/gmail/messages/{messageid}/attachments/{id}")
-    public ResponseEntity<ResponseDto> getAttachment(@RequestParam("accessToken") String accessToken,
+    public ResponseEntity<ResponseDto> getAttachment(HttpServletRequest httpServletRequest,
                                                      @PathVariable("messageid") String messageId, @PathVariable("id") String id){
         log.info("Request to get attachment in message");
         try {
-            GmailMessageAttachmentResponse response = gmailService.getAttachment(accessToken, messageId, id);
+            String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
+            GmailMessageAttachmentResponse response = gmailService.getAttachment(uid, messageId, id);
             return new ResponseEntity<>(response, HttpStatus.OK);
         }catch (Exception e){
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
@@ -97,13 +105,14 @@ public class GmailController {
 
 
     @PostMapping(value = "/api/v1/gmail/messages/send", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ResponseDto> sendMessage(@RequestParam("accessToken") String accessToken,
+    public ResponseEntity<ResponseDto> sendMessage(HttpServletRequest httpServletRequest,
                                                    @RequestPart("toEmailAddress") String toEmailAddress,
                                                    @RequestPart("subject") String subject,
                                                    @RequestPart("bodyText") String bodyText,
                                                    @RequestPart(value = "files", required = false) List<MultipartFile> files){
         log.info("Request to send message");
         try {
+            String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
             GmailMessageSendRequest request = new GmailMessageSendRequest();
             request.setToEmailAddress(toEmailAddress);
             request.setSubject(subject);

--- a/src/main/java/woozlabs/echo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/woozlabs/echo/domain/member/repository/MemberRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByUid(String uid);
 
     Optional<Member> findByGoogleProviderId(String googleProviderId);
 

--- a/src/main/java/woozlabs/echo/global/config/WebConfig.java
+++ b/src/main/java/woozlabs/echo/global/config/WebConfig.java
@@ -1,11 +1,16 @@
 package woozlabs.echo.global.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import woozlabs.echo.global.interceptor.FirebaseAuthInterceptor;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+    private final FirebaseAuthInterceptor firebaseAuthInterceptor;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -14,5 +19,11 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("GET", "POST", "PUT", "DELETE")
                 .allowedHeaders("*")
                 .allowCredentials(true);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(firebaseAuthInterceptor)
+                .addPathPatterns("/api/v1/gmail/**");
     }
 }

--- a/src/main/java/woozlabs/echo/global/constant/GlobalConstant.java
+++ b/src/main/java/woozlabs/echo/global/constant/GlobalConstant.java
@@ -4,10 +4,13 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 public final class GlobalConstant {
+    // Auth
+    public static final String AUTH_UNAUTHORIZED_ERR_MSG = "인증되지 않은 사용자입니다.";
     // End Points
     public static final String FE_HOST_ADDRESS = "http://127.0.0.1:3000";
     // Basic Char
     public static final String SPACE_CHAR = " ";
+    public static final String EMPTY_CHAR = "";
     // Gmail global
     public static final String USER_ID = "me";
     // Gmail threads
@@ -21,4 +24,6 @@ public final class GlobalConstant {
     // Email Error Message
     public static final String EMAIL_ERR_MSG_KEY = "EmailException";
     public static final String REQUEST_GMAIL_USER_MESSAGES_GET_API_ERR_MSG = "Internal Server Error: Request gmail messages get one api";
+    // firebase
+    public static final String FIREBASE_UID_KEY = "uid";
 }

--- a/src/main/java/woozlabs/echo/global/interceptor/FirebaseAuthInterceptor.java
+++ b/src/main/java/woozlabs/echo/global/interceptor/FirebaseAuthInterceptor.java
@@ -1,0 +1,42 @@
+package woozlabs.echo.global.interceptor;
+
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import woozlabs.echo.global.constant.GlobalConstant;
+import woozlabs.echo.global.utils.FirebaseTokenVerifier;
+
+import static woozlabs.echo.global.constant.GlobalConstant.*;
+
+@Component
+@RequiredArgsConstructor
+public class FirebaseAuthInterceptor implements HandlerInterceptor {
+    private final String AUTH_HEADER_NAME = "Authorization";
+    private final String AUTH_HEADER_PREFIX = "Bearer ";
+
+    private final FirebaseTokenVerifier firebaseTokenVerifier;
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String authHeader = request.getHeader(AUTH_HEADER_NAME);
+        if(authHeader == null || !authHeader.startsWith(AUTH_HEADER_PREFIX)){ // token checking
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, AUTH_UNAUTHORIZED_ERR_MSG);
+            return false;
+        }
+        String idToken = authHeader.replace(AUTH_HEADER_PREFIX, EMPTY_CHAR);
+        FirebaseToken firebaseToken;
+        try{
+            firebaseToken = firebaseTokenVerifier.verifyToken(idToken);
+        }catch (FirebaseAuthException e){
+            System.out.println(e.getMessage());
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, AUTH_UNAUTHORIZED_ERR_MSG);
+            return false;
+        }
+        // setting attribute of request obj
+        request.setAttribute(FIREBASE_UID_KEY, firebaseToken.getUid());
+        return true;
+    }
+}


### PR DESCRIPTION
### PR 메시지 
 1. 제목: [Feat]: Firebase Token 인증을 위한 인터셉터 구현
 2. 내용
- 파이어베이스 토큰 검사를 위한 인터셉터 구현

## 설명
- 클라이언트의 요청으로부터 받은 Authorization 헤더의 값 즉, 파이어베이스 토큰 값을 통해 UID를 추출하고 이를 통해 사용자의 구글 액세스 토큰을 데이터베이스에서 가져오는 코드를 작성하였습니다.
- 인터셉터를 통해 구현하였으며 요청이 핸들러에게 전달되기 전에 검사합니다.
- 현재 /api/v1/gmail/*로 시작하는 경로로 요청이 들어오면 해당 인터셉터가 동작합니다.

## 완료한 기능 명세
- [x] 파베 토큰 검증 인터셉터 구현
- [x] 첨부파일 이메일 보내기 기능 구현 완료(* #31 ) 
