### PR TITLE
[Feat] : Draft 전송 기능, 이메일 목록 조회시 내용포함 리팩토링, 이메일 읽음처리 기능

### DIFF
--- a/src/main/java/woozlabs/echo/domain/gmail/controller/GmailController.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/controller/GmailController.java
@@ -110,6 +110,22 @@ public class GmailController {
         }
     }
 
+    @PatchMapping("/api/v1/gmail/threads/{id}/modify")
+    public ResponseEntity<ResponseDto> updateThread(HttpServletRequest httpServletRequest,
+                                                    @PathVariable("id") String id,
+                                                    @RequestBody GmailThreadUpdateRequest request){
+        log.info("Request to update thread");
+        try {
+            String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
+            GmailThreadUpdateResponse response = gmailService.updateUserEmailThread(uid, id, request);
+            return new ResponseEntity<>(response, HttpStatus.NO_CONTENT);
+        }catch (IOException e){
+            throw new CustomErrorException(ErrorCode.REQUEST_GMAIL_USER_THREADS_GET_API_ERROR_MESSAGE, e.getMessage());
+        }catch (Exception e){
+            throw new CustomErrorException(ErrorCode.FAILED_TO_GET_GMAIL_CONNECTION_REQUEST);
+        }
+    }
+
     // messages
     @GetMapping("/api/v1/gmail/messages/{messageId}/attachments/{id}")
     public ResponseEntity<ResponseDto> getAttachment(HttpServletRequest httpServletRequest,
@@ -203,5 +219,5 @@ public class GmailController {
         }
     }
 }
-// update
+
 // message pub & sub

--- a/src/main/java/woozlabs/echo/domain/gmail/controller/GmailController.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/controller/GmailController.java
@@ -11,6 +11,8 @@ import org.springframework.web.multipart.MultipartFile;
 import woozlabs.echo.domain.gmail.dto.*;
 import woozlabs.echo.domain.gmail.dto.draft.GmailDraftGetResponse;
 import woozlabs.echo.domain.gmail.dto.draft.GmailDraftListResponse;
+import woozlabs.echo.domain.gmail.dto.draft.GmailDraftSendRequest;
+import woozlabs.echo.domain.gmail.dto.draft.GmailDraftSendResponse;
 import woozlabs.echo.domain.gmail.dto.message.GmailMessageAttachmentResponse;
 import woozlabs.echo.domain.gmail.dto.message.GmailMessageSendRequest;
 import woozlabs.echo.domain.gmail.dto.message.GmailMessageSendResponse;
@@ -177,4 +179,29 @@ public class GmailController {
             throw new CustomErrorException(ErrorCode.FAILED_TO_GET_GMAIL_CONNECTION_REQUEST);
         }
     }
+
+    @PostMapping(value = "/api/v1/gmail/drafts/send", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ResponseDto> sendDraft(HttpServletRequest httpServletRequest,
+                                                   @RequestPart("toEmailAddress") String toEmailAddress,
+                                                   @RequestPart("subject") String subject,
+                                                   @RequestPart("bodyText") String bodyText,
+                                                   @RequestPart(value = "files", required = false) List<MultipartFile> files) {
+        log.info("Request to send draft");
+        try {
+            String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
+            GmailDraftSendRequest request = new GmailDraftSendRequest();
+            request.setToEmailAddress(toEmailAddress);
+            request.setSubject(subject);
+            request.setBodyText(bodyText);
+            request.setFiles(files);
+            GmailDraftSendResponse response = gmailService.sendUserEmailDraft(uid, request);
+            return new ResponseEntity<>(response, HttpStatus.CREATED);
+        } catch (IOException e) {
+            throw new CustomErrorException(ErrorCode.REQUEST_GMAIL_USER_THREADS_GET_API_ERROR_MESSAGE, e.getMessage());
+        } catch (Exception e) {
+            throw new CustomErrorException(ErrorCode.FAILED_TO_GET_GMAIL_CONNECTION_REQUEST);
+        }
+    }
 }
+// update
+// message pub & sub

--- a/src/main/java/woozlabs/echo/domain/gmail/dto/draft/GmailDraftSendRequest.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/dto/draft/GmailDraftSendRequest.java
@@ -1,0 +1,15 @@
+package woozlabs.echo.domain.gmail.dto.draft;
+
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Data
+public class GmailDraftSendRequest {
+    private String toEmailAddress;
+    private String fromEmailAddress;
+    private String subject;
+    private String bodyText;
+    private List<MultipartFile> files;
+}

--- a/src/main/java/woozlabs/echo/domain/gmail/dto/draft/GmailDraftSendResponse.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/dto/draft/GmailDraftSendResponse.java
@@ -1,4 +1,4 @@
-package woozlabs.echo.domain.gmail.dto.message;
+package woozlabs.echo.domain.gmail.dto.draft;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -6,9 +6,9 @@ import woozlabs.echo.global.dto.ResponseDto;
 
 import java.util.List;
 
-@Getter
 @Builder
-public class GmailMessageSendResponse implements ResponseDto {
+@Getter
+public class GmailDraftSendResponse implements ResponseDto {
     private String id;
     private String threadId;
     private List<String> labelsId;

--- a/src/main/java/woozlabs/echo/domain/gmail/dto/thread/GmailThreadListThreads.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/dto/thread/GmailThreadListThreads.java
@@ -15,6 +15,7 @@ public class GmailThreadListThreads implements Comparable<GmailThreadListThreads
     private String mimeType;
     private int attachmentSize;
     private List<GmailThreadListAttachments> attachments;
+    private List<GmailThreadGetMessages> messages;
     private List<String> fromName;
     private List<String> fromEmail;
     private String subject;

--- a/src/main/java/woozlabs/echo/domain/gmail/dto/thread/GmailThreadUpdateRequest.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/dto/thread/GmailThreadUpdateRequest.java
@@ -1,0 +1,11 @@
+package woozlabs.echo.domain.gmail.dto.thread;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class GmailThreadUpdateRequest {
+    private List<String> addLabelIds;
+    private List<String> removeLabelIds;
+}

--- a/src/main/java/woozlabs/echo/domain/gmail/dto/thread/GmailThreadUpdateResponse.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/dto/thread/GmailThreadUpdateResponse.java
@@ -1,0 +1,14 @@
+package woozlabs.echo.domain.gmail.dto.thread;
+
+import lombok.Builder;
+import lombok.Data;
+import woozlabs.echo.global.dto.ResponseDto;
+
+import java.util.List;
+
+@Data
+@Builder
+public class GmailThreadUpdateResponse implements ResponseDto {
+    private List<String> addLabelIds;
+    private List<String> removeLabelIds;
+}

--- a/src/main/java/woozlabs/echo/domain/gmail/service/GmailService.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/service/GmailService.java
@@ -221,6 +221,23 @@ public class GmailService {
                 .build();
     }
 
+    public GmailThreadUpdateResponse updateUserEmailThread(String uid, String id, GmailThreadUpdateRequest request) throws Exception{
+        Member member = memberRepository.findByUid(uid).orElseThrow(
+                () -> new CustomErrorException(ErrorCode.NOT_FOUND_MEMBER_ERROR_MESSAGE));
+        String accessToken = member.getAccessToken();
+        Gmail gmailService = createGmailService(accessToken);
+        ModifyThreadRequest modifyThreadRequest = new ModifyThreadRequest();
+        modifyThreadRequest.setAddLabelIds(request.getAddLabelIds());
+        modifyThreadRequest.setRemoveLabelIds(request.getRemoveLabelIds());
+        Thread thread = gmailService.users().threads().modify(USER_ID, id, modifyThreadRequest).execute();
+        System.out.println("hihihi");
+        System.out.println(thread);
+        return GmailThreadUpdateResponse.builder()
+                .addLabelIds(request.getAddLabelIds())
+                .removeLabelIds(request.getRemoveLabelIds())
+                .build();
+    }
+
     // Methods : get something
     private List<GmailThreadListThreads> getDetailedThreads(List<Thread> threads, Gmail gmailService) {
         List<CompletableFuture<Optional<GmailThreadListThreads>>> futures = threads.stream()

--- a/src/main/java/woozlabs/echo/domain/gmail/util/GmailUtil.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/util/GmailUtil.java
@@ -1,5 +1,6 @@
 package woozlabs.echo.domain.gmail.util;
 
+import org.apache.commons.codec.binary.Base64;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
@@ -8,13 +9,19 @@ import java.util.regex.Pattern;
 
 @Component
 public class GmailUtil {
-    private final Pattern NO_REPLY_PATTERN = Pattern.compile("\\bno.*reply\\b", Pattern.CASE_INSENSITIVE);
+    private final Pattern NO_REPLY_PATTERN = Pattern.compile("\\bno.*reply.*\\b", Pattern.CASE_INSENSITIVE);
     public Optional<String> extractVerification(String content, String sender){
         // check sender's email address
         if(!isVerificationEmail(sender)) return Optional.empty();
         // Decoding by using base64
         String code = "test";
         return Optional.of(code);
+    }
+
+    public String purifyEmailContent(String content){
+        byte[] decodedBytes = Base64.decodeBase64(content);
+        
+        return "test";
     }
 
     private boolean isVerificationEmail(String sender){

--- a/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
+++ b/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     // email
     REQUEST_GMAIL_USER_THREADS_GET_API_ERROR_MESSAGE(500, "Failed to get gmail threads api"),
     REQUEST_GMAIL_USER_MESSAGES_SEND_API_ERROR_MESSAGE(500, "Failed to send gmail messages api"),
+    REQUEST_GMAIL_USER_DRAFTS_SEND_API_ERROR_MESSAGE(500, "Failed to send draft messages api"),
     FAILED_TO_GET_GMAIL_CONNECTION_REQUEST(500, "Failed to get connection gmail api"),
 
     // calendar


### PR DESCRIPTION
### PR 메시지 
 1. 제목: [Feat] : Draft 전송 기능, 이메일 목록 조회시 내용포함 리팩토링, 이메일 읽음처리 기능
 2. 내용: Gmail Draft 전송 기능 구현 완료, 기존의 이메일 목록 조회 기능에서 이메일 내용이 포함되어되도록 변경함. 이메일 읽음처리를 위해 Label을 업데이트 할 수 있도록 기능을 구현하였음

## 설명
- Draft 전송 기능 구현 완료
- 기존의 이메일 목록 조회 기능에서 이메일 내용이 포함되어되도록 변경
- 이메일 읽음처리를 위해 Label을 업데이트 할 수 있도록 기능을 구현

## 완료한 기능 명세
- [x] Draft Send 기능
- [x] Gmail List 조회 기능 리팩토링
- [x] 이메일 읽음처리를 위한 Label 업데이트 기능 구현 완료   

### 스크린샷
- 이메일 읽기 전
![image](https://github.com/user-attachments/assets/9ff673f4-3bca-40bc-8e74-ea06ed7d6655)
- 이메일 읽은 후
![image](https://github.com/user-attachments/assets/c5e891a2-ac9f-4faf-8e12-16001d95b6be)

