### PR TITLE
[Fix]: 첨부파일 중복 문제 해결 & 타입존 UTC로 통합

### DIFF
--- a/src/main/java/woozlabs/echo/domain/gmail/dto/thread/GmailThreadListThreads.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/dto/thread/GmailThreadListThreads.java
@@ -20,7 +20,7 @@ public class GmailThreadListThreads implements Comparable<GmailThreadListThreads
     private List<String> fromEmail;
     private String subject;
     private String snippet;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime internalDate;
     private int threadSize;
 


### PR DESCRIPTION
### PR 메시지 
 1. 제목: [Fix]: 첨부파일 중복 문제 해결
 2. 내용
- 메일 조회시 인라인 파일도 첨부파일로 처리되는 문제가 발생 -> 해결
- 타임존 모두 UTC로 통합

## 설명
- 메일 조회시 인라인 파일도 첨부파일로 처리되는 문제가 발생 -> 해결
- 메일 내용 내에 인라인으로 이미지 파일을 보내경우 첨부파일로 된 파일이 하나 더 추가가 되는데 이것을 2개의 파일로 인식하는 경우가 발생했음. 이를 해결하기 위해 인라인 파일은 무시하도록 필터링 메서드를 개발함.
- 타임존 모두 UTC로 통합. 이전에는 모든 메일이 타임존이 달랐음.

## 완료한 기능 명세
- [x] 타임존 UTC 통합
- [x] 첨부파일 문제 해결  

### 스크린샷
- 변경전
<img width="305" alt="Content-Disposition" src="https://github.com/user-attachments/assets/03fdef26-db0f-43b5-8379-5651a1d7911e">


- 변경후
<img width="895" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/56aee1fb-ce82-44a4-8b23-0b46005d1daf">

