### PR TITLE
[FEAT] Token Member, SuperAccount 동기화

### DIFF
--- a/src/main/java/woozlabs/echo/domain/member/service/TokenSchedulerService.java
+++ b/src/main/java/woozlabs/echo/domain/member/service/TokenSchedulerService.java
@@ -70,6 +70,12 @@ public class TokenSchedulerService {
             member.setAccessToken(newAccessToken);
             member.setAccessTokenFetchedAt(LocalDateTime.now());
             memberRepository.save(member);
+
+            SuperAccount superAccount = superAccountRepository.findByMember(member)
+                    .orElseThrow(() -> new CustomErrorException(ErrorCode.NOT_FOUND_SUPER_ACCOUNT));
+            superAccount.setAccessToken(newAccessToken);
+            superAccount.setAccessTokenFetchedAt(LocalDateTime.now());
+            superAccountRepository.save(superAccount);
         } catch (Exception e) {
             throw new CustomErrorException(ErrorCode.FAILED_TO_REFRESH_GOOGLE_TOKEN);
         }

--- a/src/main/java/woozlabs/echo/global/constant/GlobalConstant.java
+++ b/src/main/java/woozlabs/echo/global/constant/GlobalConstant.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 public final class GlobalConstant {
     // Auth
     public static final String AUTH_UNAUTHORIZED_ERR_MSG = "인증되지 않은 사용자입니다.";
+    public static final String AUTH_SIGN_IN_DOMAIN = "https://echo-homepage.vercel.app/sign-in";
     // End Points
     public static final String FE_HOST_ADDRESS = "http://127.0.0.1:3000";
     // Basic Char


### PR DESCRIPTION

## 설명
- close #70
- Token 스케줄러에서 예상치 못한 NullPoint Exception 발생
- 정확한 이유는 모르겠으나, DB 확인 결과 멤버와 슈퍼어카운트의 리프레쉬 토큰 값이 다른것을 확인
- SubAccount는 우선 처리하지않습니다.

## 완료한 기능 명세
- [x] Member, SuperAccount Table 리프레쉬토큰 동기화

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

