### PR TITLE
[FEAT] Verification gemini & ChatGPT Setting 및 초안 설계 구현

### DIFF
--- a/src/main/java/woozlabs/echo/domain/chatGPT/ChatGPTInterface.java
+++ b/src/main/java/woozlabs/echo/domain/chatGPT/ChatGPTInterface.java
@@ -1,0 +1,14 @@
+package woozlabs.echo.domain.chatGPT;
+
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.annotation.PostExchange;
+import woozlabs.echo.domain.chatGPT.dto.ChatGPTRequest;
+import woozlabs.echo.domain.chatGPT.dto.ChatGPTResponse;
+
+@HttpExchange("/v1")
+public interface ChatGPTInterface {
+
+    @PostExchange("/chat/completions")
+    ChatGPTResponse getChatCompletion(@RequestBody ChatGPTRequest request);
+}

--- a/src/main/java/woozlabs/echo/domain/chatGPT/controller/ChatGptController.java
+++ b/src/main/java/woozlabs/echo/domain/chatGPT/controller/ChatGptController.java
@@ -1,0 +1,29 @@
+package woozlabs.echo.domain.chatGPT.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import woozlabs.echo.domain.chatGPT.service.ChatGptService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chatGpt")
+public class ChatGptController {
+
+    private final ChatGptService chatGptService;
+
+    @PostMapping("/completion")
+    public ResponseEntity<String> getCompletion(@RequestBody String text) {
+        String completion = chatGptService.getCompletion(text);
+        return ResponseEntity.ok(completion);
+    }
+
+    @PostMapping("/gmail/verification")
+    public ResponseEntity<String> analyzeEmail(@RequestBody String emailContent) {
+        String result = chatGptService.analyzeVerificationEmail(emailContent);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/woozlabs/echo/domain/chatGPT/dto/ChatGPTRequest.java
+++ b/src/main/java/woozlabs/echo/domain/chatGPT/dto/ChatGPTRequest.java
@@ -1,0 +1,29 @@
+package woozlabs.echo.domain.chatGPT.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ChatGPTRequest {
+    private String model;
+    private List<Message> messages;
+
+    public ChatGPTRequest(String model, String content) {
+        this.model = model;
+        this.messages = List.of(new Message("user", content));
+    }
+
+    @Getter
+    public static class Message {
+        private String role;
+        private String content;
+
+        public Message(String role, String content) {
+            this.role = role;
+            this.content = content;
+        }
+    }
+}

--- a/src/main/java/woozlabs/echo/domain/chatGPT/dto/ChatGPTResponse.java
+++ b/src/main/java/woozlabs/echo/domain/chatGPT/dto/ChatGPTResponse.java
@@ -1,0 +1,23 @@
+package woozlabs.echo.domain.chatGPT.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ChatGPTResponse {
+    private List<Choice> choices;
+
+    @Getter
+    public static class Choice {
+        private Message message;
+    }
+
+    @Getter
+    public static class Message {
+        private String content;
+        private String role;
+    }
+}

--- a/src/main/java/woozlabs/echo/domain/chatGPT/service/ChatGptService.java
+++ b/src/main/java/woozlabs/echo/domain/chatGPT/service/ChatGptService.java
@@ -1,0 +1,67 @@
+package woozlabs.echo.domain.chatGPT.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Service;
+import woozlabs.echo.domain.chatGPT.ChatGPTInterface;
+import woozlabs.echo.domain.chatGPT.dto.ChatGPTRequest;
+import woozlabs.echo.domain.chatGPT.dto.ChatGPTResponse;
+import woozlabs.echo.domain.gemini.prompt.VerificationMailPrompt;
+import woozlabs.echo.global.exception.CustomErrorException;
+import woozlabs.echo.global.exception.ErrorCode;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatGptService {
+
+    private static final String GPT_4 = "gpt-4o-mini";
+
+    private final ChatGPTInterface chatGPTInterface;
+
+    private ChatGPTResponse getChatCompletion(ChatGPTRequest request) {
+        try {
+            return chatGPTInterface.getChatCompletion(request);
+        } catch (Exception e) {
+            log.error("Error while getting completion from ChatGPT", e);
+            throw new CustomErrorException(ErrorCode.FAILED_TO_CHATGPT_COMPLETION, e.getMessage());
+        }
+    }
+
+    public String getCompletion(String text) {
+        ChatGPTRequest chatGPTRequest = new ChatGPTRequest(GPT_4, text);
+        ChatGPTResponse response = getChatCompletion(chatGPTRequest);
+
+        return response.getChoices()
+                .stream()
+                .findFirst()
+                .map(choice -> choice.getMessage().getContent())
+                .orElse(null);
+    }
+
+    public String analyzeVerificationEmail(String emailContent) {
+        // Filtering 거쳐서 받아오기
+        //String coreContent = extractCoreContent(emailContent);
+
+        String prompt = VerificationMailPrompt.getPrompt(emailContent);
+        return getCompletion(prompt);
+    }
+
+//    private String extractCoreContent(String htmlContent) {
+//        Document doc = Jsoup.parse(htmlContent);
+//
+//        doc.select("style, script, head, title, meta, img").remove();
+//        doc.select("table, tbody, tr, td, th, thead, tfoot").unwrap();
+//        Elements coreElements = doc.select("div, p, h1, h2, h3, a, pre, span, td");
+//
+//        for (Element coreElement : coreElements) {
+//            coreElement.clearAttributes();
+//        }
+//
+//        return coreElements.toString();
+//    }
+}

--- a/src/main/java/woozlabs/echo/domain/gemini/controller/GeminiController.java
+++ b/src/main/java/woozlabs/echo/domain/gemini/controller/GeminiController.java
@@ -85,4 +85,10 @@ public class GeminiController {
             throw new CustomErrorException(ErrorCode.FAILED_TO_EXTRACT_KEYPOINT, e.getMessage());
         }
     }
+
+    @PostMapping("/gmail/verification")
+    public ResponseEntity<String> analyzeEmail(@RequestBody String emailContent) {
+        String result = geminiService.analyzeVerificationEmail(emailContent);
+        return ResponseEntity.ok(result);
+    }
 }

--- a/src/main/java/woozlabs/echo/domain/gemini/prompt/VerificationMailPrompt.java
+++ b/src/main/java/woozlabs/echo/domain/gemini/prompt/VerificationMailPrompt.java
@@ -1,0 +1,26 @@
+package woozlabs.echo.domain.gemini.prompt;
+
+public class VerificationMailPrompt {
+
+    private static final String VERIFICATION_MAIL_ANALYSIS = """
+          Analyze the following email content and determine if it's an account verification email.
+          
+          Guidelines:
+          1. If it's not a verification email, respond with: <not_verification>
+          2. If it is a verification email, follow these steps:
+             a. Look for a verification URL. If found, respond with: <url=FULL_URL>
+             b. If no URL is present, look for a verification code. If found, respond with: <code=VERIFICATION_CODE>
+          3. Ensure your response contains ONLY the requested format, without any additional text.
+          4. If you can't determine if it's a verification email or can't find a URL or code, respond with: <unknown>
+          
+          Analyze the following email content:
+
+          %s
+
+          Response (ONLY in the specified format):
+          """;
+
+    public static String getPrompt(String threadContent) {
+        return String.format(VERIFICATION_MAIL_ANALYSIS, threadContent);
+    }
+}

--- a/src/main/java/woozlabs/echo/domain/gemini/prompt/VerificationMailPrompt.java
+++ b/src/main/java/woozlabs/echo/domain/gemini/prompt/VerificationMailPrompt.java
@@ -3,22 +3,25 @@ package woozlabs.echo.domain.gemini.prompt;
 public class VerificationMailPrompt {
 
     private static final String VERIFICATION_MAIL_ANALYSIS = """
-          Analyze the following email content and determine if it's an account verification email.
-          
-          Guidelines:
-          1. If it's not a verification email, respond with: <not_verification>
-          2. If it is a verification email, follow these steps:
-             a. Look for a verification URL. If found, respond with: <url=FULL_URL>
-             b. If no URL is present, look for a verification code. If found, respond with: <code=VERIFICATION_CODE>
-          3. Ensure your response contains ONLY the requested format, without any additional text.
-          4. If you can't determine if it's a verification email or can't find a URL or code, respond with: <unknown>
-          
-          Analyze the following email content:
+        You are a professional email analyzer. Your job is to determine if an email is an account verification email and extract relevant information.
 
-          %s
-
-          Response (ONLY in the specified format):
-          """;
+        Instructions:
+        1. Analyze the following email content.
+        2. If it's an account verification email:
+           - If there's a URL, respond with: <url_title=URL>
+           - If there's a verification code, respond with: <code=VERIFICATION_CODE>
+        3. If it's not a verification email, respond with: "false"
+        4. If you're unsure, respond with: "unknown"
+    
+        Provide only the requested response without any additional explanation.
+    
+        Email content to analyze:
+        ===
+        %s
+        ===
+    
+        Your analysis (respond ONLY with <url_title=URL>, <code=VERIFICATION_CODE>, "false", or "unknown"):
+        """;
 
     public static String getPrompt(String threadContent) {
         return String.format(VERIFICATION_MAIL_ANALYSIS, threadContent);

--- a/src/main/java/woozlabs/echo/domain/gemini/prompt/VerificationMailPrompt.java
+++ b/src/main/java/woozlabs/echo/domain/gemini/prompt/VerificationMailPrompt.java
@@ -5,11 +5,15 @@ public class VerificationMailPrompt {
     private static final String VERIFICATION_MAIL_ANALYSIS = """
         You are a professional email analyzer. Your job is to determine if an email is an account verification email and extract relevant information.
 
+        Definition:
+        An account verification email includes emails sent for purposes such as email verification, password reset, account activation, or any email requiring the user to verify their identity or actions.
+
         Instructions:
         1. Analyze the following email content.
-        2. If it's an account verification email:
-           - If there's a URL, respond with: <url_title=URL>
-           - If there's a verification code, respond with: <code=VERIFICATION_CODE>
+        2. If it's an account verification email in HTML format:
+           - If there's a URL, respond with: <element=ELEMENT, id=ID_ATTRIBUTE>
+           - If there's a verification code, respond with: <element=ELEMENT, id=ID_ATTRIBUTE>
+           - Ensure that ID_ATTRIBUTE is the four-digit number id attribute of the element containing the verification URL or code.
         3. If it's not a verification email, respond with: "false"
         4. If you're unsure, respond with: "unknown"
     
@@ -20,7 +24,7 @@ public class VerificationMailPrompt {
         %s
         ===
     
-        Your analysis (respond ONLY with <url_title=URL>, <code=VERIFICATION_CODE>, "false", or "unknown"):
+        Your analysis (respond ONLY with <element=ELEMENT, id=ID_ATTRIBUTE>, "false", or "unknown"):
         """;
 
     public static String getPrompt(String threadContent) {

--- a/src/main/java/woozlabs/echo/domain/gemini/service/GeminiService.java
+++ b/src/main/java/woozlabs/echo/domain/gemini/service/GeminiService.java
@@ -129,6 +129,8 @@ public class GeminiService {
 
     public String analyzeVerificationEmail(String emailContent) {
         String coreContent = extractCoreContent(emailContent);
+
+        System.out.println("coreContent = " + coreContent);
         String prompt = VerificationMailPrompt.getPrompt(coreContent);
         return getCompletion(prompt);
     }
@@ -136,8 +138,23 @@ public class GeminiService {
     private String extractCoreContent(String htmlContent) {
         Document doc = Jsoup.parse(htmlContent);
 
-        doc.select("style, script, head, title, meta").remove();
+        doc.select("style, script, head, title, meta, img").remove();
+        doc.select("table, tbody, tr, td, th, thead, tfoot").unwrap();
         Elements coreElements = doc.select("div, p, h1, h2, h3, a, pre, span, td");
+
+        for (Element coreElement : coreElements) {
+            coreElement.removeAttr("style");
+            coreElement.removeAttr("class");
+            coreElement.removeAttr("id");
+            coreElement.removeAttr("align");
+            coreElement.removeAttr("width");
+            coreElement.removeAttr("height");
+            coreElement.removeAttr("valign");
+            coreElement.removeAttr("bgcolor");
+            coreElement.removeAttr("cellpadding");
+            coreElement.removeAttr("cellspacing");
+            coreElement.removeAttr("border");
+        }
 
         return coreElements.toString();
     }

--- a/src/main/java/woozlabs/echo/domain/gemini/service/GeminiService.java
+++ b/src/main/java/woozlabs/echo/domain/gemini/service/GeminiService.java
@@ -4,12 +4,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 import woozlabs.echo.domain.gemini.GeminiInterface;
 import woozlabs.echo.domain.gemini.dto.GeminiRequest;
 import woozlabs.echo.domain.gemini.dto.GeminiResponse;
 import woozlabs.echo.domain.gemini.prompt.ThreadKeypointPrompt;
 import woozlabs.echo.domain.gemini.prompt.ThreadSummaryPrompt;
+import woozlabs.echo.domain.gemini.prompt.VerificationMailPrompt;
 import woozlabs.echo.domain.gmail.dto.thread.*;
 import woozlabs.echo.global.exception.CustomErrorException;
 import woozlabs.echo.global.exception.ErrorCode;
@@ -122,5 +125,20 @@ public class GeminiService {
     public String keypoint(String text) {
         String prompt = ThreadKeypointPrompt.getPrompt(text);
         return getCompletion(prompt);
+    }
+
+    public String analyzeVerificationEmail(String emailContent) {
+        String coreContent = extractCoreContent(emailContent);
+        String prompt = VerificationMailPrompt.getPrompt(coreContent);
+        return getCompletion(prompt);
+    }
+
+    private String extractCoreContent(String htmlContent) {
+        Document doc = Jsoup.parse(htmlContent);
+
+        doc.select("style, script, head, title, meta").remove();
+        Elements coreElements = doc.select("div, p, h1, h2, h3, a, pre, span, td");
+
+        return coreElements.toString();
     }
 }

--- a/src/main/java/woozlabs/echo/domain/member/service/TokenSchedulerService.java
+++ b/src/main/java/woozlabs/echo/domain/member/service/TokenSchedulerService.java
@@ -28,7 +28,7 @@ public class TokenSchedulerService {
     @Scheduled(fixedRate = 5 * 60 * 1000)
     @Transactional
     public void checkAndRefreshTokens() {
-        LocalDateTime cutoffTime = LocalDateTime.now().minus(57, ChronoUnit.MINUTES);
+        LocalDateTime cutoffTime = LocalDateTime.now().minus(50, ChronoUnit.MINUTES);
         List<Member> members = memberRepository.findMembersByCutoffTime(cutoffTime);
         for (Member member : members) {
             if (shouldRefreshToken(member.getAccessTokenFetchedAt())) {

--- a/src/main/java/woozlabs/echo/global/config/RestTemplateConfig.java
+++ b/src/main/java/woozlabs/echo/global/config/RestTemplateConfig.java
@@ -20,6 +20,7 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.client.support.RestClientAdapter;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+import woozlabs.echo.domain.chatGPT.ChatGPTInterface;
 import woozlabs.echo.domain.gemini.GeminiInterface;
 
 import java.util.Arrays;
@@ -89,5 +90,22 @@ public class RestTemplateConfig {
         RestClientAdapter adapter = RestClientAdapter.create(client);
         HttpServiceProxyFactory factory = HttpServiceProxyFactory.builderFor(adapter).build();
         return factory.createClient(GeminiInterface.class);
+    }
+
+    @Bean
+    public RestClient chatGPTRestClient(@Value("${chatgpt.api.url}") String apiUrl,
+                                        @Value("${chatgpt.api.key}") String apiKey) {
+        return RestClient.builder()
+                .baseUrl(apiUrl)
+                .defaultHeader("Authorization", "Bearer " + apiKey)
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+
+    @Bean
+    public ChatGPTInterface chatGPTInterface(@Qualifier("chatGPTRestClient") RestClient client) {
+        RestClientAdapter adapter = RestClientAdapter.create(client);
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builderFor(adapter).build();
+        return factory.createClient(ChatGPTInterface.class);
     }
 }

--- a/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
+++ b/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
@@ -58,6 +58,9 @@ public enum ErrorCode {
     FAILED_TO_SUMMARIZE_TEXT(500, "Error summarizing text from Gemini"),
     FAILED_TO_EXTRACT_KEYPOINT(500, "Error extracting keypoint from Gemini"),
 
+    // chatGPT
+    FAILED_TO_CHATGPT_COMPLETION(500, "Error while getting completion from chatGPT"),
+
     // Email Template
     FAILED_TO_FETCHING_EMAIL_TEMPLATE(500, "Error occurred while fetching email templates for user"),
     FAILED_TO_CREATE_EMAIL_TEMPLATE(500, "Error occurred while creating email templates for user"),


### PR DESCRIPTION
## 설명
- close #102 
- 이메일 Thread HTML Content를 받아옵니다.
- 해당 컨텐츠를 필요한 태그만 남기고 파싱 처리합니다.
- 파싱하고 남은 값을 가지고 해당 메일이 Verification 메일인지 아닌지를 판별하고, 맞다면 Code or URL을 반환합니다.
- 인증 메일이 아니라면 `false`만 반환합니다.
- 인증 메일일 시 url이 주어진다면 `<url_title=https://link.t~~~`
- Code가 주어진다면 `<code=123456>`
- 결과 캡쳐본들은 슬랙에서 확인

## 완료한 기능 명세
- [x] 파싱
- [x] 반환
- [x] 프롬포팅 수정
- [x] ChatGPT Setting
- [x] ChatGPT 코드 작성
- [x] 토큰 교체 주기 cutoffTime 수정 57 -> 50

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

