### PR TITLE
[REFACTOR] 중복 시간 검사 로직 수정

### DIFF
--- a/src/main/java/woozlabs/echo/domain/member/service/TokenSchedulerService.java
+++ b/src/main/java/woozlabs/echo/domain/member/service/TokenSchedulerService.java
@@ -31,20 +31,8 @@ public class TokenSchedulerService {
         LocalDateTime cutoffTime = LocalDateTime.now().minus(57, ChronoUnit.MINUTES);
         List<Member> members = memberRepository.findMembersByCutoffTime(cutoffTime);
         for (Member member : members) {
-            if (shouldRefreshToken(member.getAccessTokenFetchedAt())) {
-                refreshToken(member);
-            }
+            refreshToken(member);
         }
-    }
-
-    private boolean shouldRefreshToken(LocalDateTime tokenFetchedAt) {
-        if (tokenFetchedAt == null) {
-            return false;
-        }
-        LocalDateTime now = LocalDateTime.now();
-        long minutesElapsed = ChronoUnit.MINUTES.between(tokenFetchedAt, now);
-
-        return minutesElapsed >= 50;
     }
 
     public void refreshToken(Member member) {


### PR DESCRIPTION
## 설명
- 저번 account 수정 이후로 토큰 스케줄러 코드를 수정했었는데 최적화를 좀 더 진행합니다.
- 수정 전 로직은 토큰을 발급 받은 후로부터 50분이 지난 멤버를 리스트로 뽑아냅니다.
- 그리고 해당 멤버들이 50분이 지났는지 또 한번 재검사를 한 후 리프레쉬를 요청합니다.
- 여기서 한번 더 재검사를 하는 로직이 불필요하다고 판단되어 코드를 수정합니다.

## 완료한 기능 명세
- [x] 코드 정리

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

