### PR TITLE
[Feat]: 인증 메일 링크 추출 기능 GPT 연동 성공

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 	implementation 'com.google.apis:google-api-services-calendar:v3-rev20220715-2.0.0'
 	implementation 'com.google.apis:google-api-services-gmail:v1-rev20240520-2.0.0'
 	implementation 'com.google.auth:google-auth-library-oauth2-http:1.19.0'
-	implementation group: 'javax.mail', name: 'mail', version: '1.4'
+	implementation 'com.sun.mail:jakarta.mail:2.0.1'
 	implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.3.1'
 	implementation group: 'com.google.firebase', name: 'firebase-admin', version: '9.3.0'
 	implementation 'org.jsoup:jsoup:1.15.3'

--- a/src/main/java/woozlabs/echo/domain/gmail/dto/thread/GmailThreadGetMessages.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/dto/thread/GmailThreadGetMessages.java
@@ -115,11 +115,11 @@ public class GmailThreadGetMessages {
         gmailThreadGetMessages.setHistoryId(message.getHistoryId());
         gmailThreadGetMessages.setPayload(convertedPayload);
         // verification code
-//        ExtractVerificationInfo verificationInfo = findVerificationEmail(convertedPayload, gmailUtility);
-//        if(!verificationInfo.getCodes().isEmpty() || !verificationInfo.getLinks().isEmpty()){
-//            verificationInfo.setVerification(Boolean.TRUE);
-//        }
-//        gmailThreadGetMessages.setVerification(verificationInfo);
+        ExtractVerificationInfo verificationInfo = findVerificationEmail(convertedPayload, gmailUtility);
+        if(!verificationInfo.getCodes().isEmpty() || !verificationInfo.getLinks().isEmpty()){
+            verificationInfo.setVerification(Boolean.TRUE);
+        }
+        gmailThreadGetMessages.setVerification(verificationInfo);
         return gmailThreadGetMessages;
     }
 

--- a/src/main/java/woozlabs/echo/domain/gmail/service/GmailService.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/service/GmailService.java
@@ -11,6 +11,16 @@ import com.google.api.services.gmail.model.Thread;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
+import jakarta.activation.DataHandler;
+import jakarta.activation.DataSource;
+import jakarta.activation.FileDataSource;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Base64;
@@ -33,16 +43,6 @@ import woozlabs.echo.global.constant.GlobalConstant;
 import woozlabs.echo.global.exception.CustomErrorException;
 import woozlabs.echo.global.exception.ErrorCode;
 
-import javax.activation.DataHandler;
-import javax.activation.DataSource;
-import javax.activation.FileDataSource;
-import javax.mail.MessagingException;
-import javax.mail.Multipart;
-import javax.mail.Session;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -437,7 +437,7 @@ public class GmailService {
         MimeMessage email = new MimeMessage(session);
         // setting base
         email.setFrom(new InternetAddress(request.getFromEmailAddress()));
-        email.addRecipient(javax.mail.Message.RecipientType.TO,
+        email.addRecipient(jakarta.mail.Message.RecipientType.TO,
                 new InternetAddress(request.getToEmailAddress()));
         email.setSubject(request.getSubject());
         // setting body
@@ -467,7 +467,7 @@ public class GmailService {
         MimeMessage email = new MimeMessage(session);
         // setting base
         email.setFrom(new InternetAddress(request.getFromEmailAddress()));
-        email.addRecipient(javax.mail.Message.RecipientType.TO,
+        email.addRecipient(jakarta.mail.Message.RecipientType.TO,
                 new InternetAddress(request.getToEmailAddress()));
         email.setSubject(request.getSubject());
         // setting body

--- a/src/main/java/woozlabs/echo/domain/gmail/util/GmailUtility.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/util/GmailUtility.java
@@ -53,14 +53,14 @@ public class GmailUtility {
         }
         byte[] decodedBinaryContent = Base64.getDecoder().decode(standardBase64);
         String decodedContent = new String(decodedBinaryContent, StandardCharsets.UTF_8);
-        if(!isVerificationEmail(decodedContent)) return extractVerificationInfo; // check verification email
-        links.addAll(getVerificationLink(decodedContent));
-        codes.addAll(getVerificationCode(decodedContent));
-        if(!codes.isEmpty() || !links.isEmpty()){
-            extractVerificationInfo.setVerification(Boolean.TRUE);
-        }
-        extractVerificationInfo.setLinks(links);
-        extractVerificationInfo.setCodes(codes);
+//        if(!isVerificationEmail(decodedContent)) return extractVerificationInfo; // check verification email
+//        links.addAll(getVerificationLink(decodedContent));
+//        codes.addAll(getVerificationCode(decodedContent));
+//        if(!codes.isEmpty() || !links.isEmpty()){
+//            extractVerificationInfo.setVerification(Boolean.TRUE);
+//        }
+//        extractVerificationInfo.setLinks(links);
+//        extractVerificationInfo.setCodes(codes);
         return extractVerificationInfo;
     }
 

--- a/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
+++ b/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
@@ -78,7 +78,9 @@ public enum ErrorCode {
     NOT_FOUND_CONTACT_GROUP(404, "Not Found: Contact Group"),
 
     // verification
-    KEYWORD_IO_EXCEPTION(500, "I/O Exception finding verification keywords");
+    KEYWORD_IO_EXCEPTION(500, "I/O Exception finding verification keywords"),
+    EXTRACT_VERIFICATION_LINK_ERR(500, "Extract Verification Link Error"),
+    EXTRACT_VERIFICATION_CODE_ERR(500, "Extract Verification Code Error");
 
     private final int status;
     private final String message;

--- a/src/main/resources/keywords_en.txt
+++ b/src/main/resources/keywords_en.txt
@@ -1,1 +1,1 @@
-verification, authentication, otp, one-time, verify, confirm
+verification, verify, authentication, otp, one-time, confirm


### PR DESCRIPTION
### PR 메시지 
 1. 제목: [Feat]: 인증 메일 링크 추출 기능 GPT 연동 성공
 2. 내용: 인증 메일 링크 추출 기능 구현

## 설명
- 메일에서 인증 링크를 추출하는 기능을 구현하였습니다. 로직은 다음과 같습니다.
1. 이메일 내용 Base64 디코딩 후 1차 필터링
2. 1차 필터링은 자체적으로 구현한 "keywords_en.txt"과 "keywords_ko.txt"에 작성된 키워드를 확인하며 해당 키워드가 포함된 태그 또는 <a> 태그이면서 내부 텍스트에 키워드를 가지고 있는 경우의 Element를 모두 수집합니다.
3. 필요하지 않은 태그들을 제거합니다. -> Ex. style, script ..
4. <a> 태그를 제외한 내용이 없는 태그를 제거합니다.
5. href 속성을 제외하고 모든 Attribute를 제거합니다.
6. url이 너무 길 수 있으므로 자원을 표시하는 뒷 부분을 제거한 메인 도메인만 남기도록 합니다.
7. 각 태그에 id로 "%04d" 형태의 번호를 부여합니다.
8. GPT 연동을 통해 인증 링크가 존재하는 부분의 id를 반환받습니다. 만약 인증 이메일이 아니라면 false 값을 반환하도록 @ldhbenecia 님이 프롬프팅 코딩을 해주셨습니다.
9. 반환받은 결과값을 가지고 false가 아닌 id 값을 반환받았을 경우 해당 id 태그의 href 링크를 가져와 반환합니다.

- 위의 방법을 적용한 이후 GPT의 Input으로 들어가는 글자수가 약 6000자에서 -> 
- 아직 인증 코드에는 적용되지 않았습니다. 인증 링크 추출 기능에만 적용된 상태입니다.
- 현재 결과값은 제대로 나오지만 속도가 이전의 약 2초보다 3초 느려진 약 5초가 소요되는 것을 확인할 수 있습니다. -> 이후에는 속도 개선이 필요할 것 같습니다.

## 완료한 기능 명세
- [x] 인증 링크 추출 기능
- [x] GPT 연동

### 스크린샷
- 최적화 전
<img width="564" alt="A252F252Fautodesk com252Faud252Fv2252Faiwtexp6026code cl" src="https://github.com/user-attachments/assets/a0f25762-6997-4087-9418-1da248ba15a6">

- 최적화 후
<img width="563" alt="4146 byte" src="https://github.com/user-attachments/assets/9e925757-c3d9-49c2-97c8-e1ae67eaca6a">

- 인증 링크 추출
![image](https://github.com/user-attachments/assets/bbf70875-0d2f-4ef6-af7e-2f4cdcd56be7)


## 리뷰 요청 사항
- 속도 개선 방안이 있다면 말씀해주세요!

