### PR TITLE
[FEAT] Auth Custom Claims 적용

### DIFF
--- a/src/main/java/woozlabs/echo/domain/member/service/AuthService.java
+++ b/src/main/java/woozlabs/echo/domain/member/service/AuthService.java
@@ -39,6 +39,14 @@ public class AuthService {
         }
     }
 
+    private void setCustomUidClaims(String uid, Map<String, Object> claims) {
+        try {
+            FirebaseAuth.getInstance().setCustomUserClaims(uid, claims);
+        } catch (FirebaseAuthException e) {
+            throw new CustomErrorException(ErrorCode.FAILED_TO_SET_CUSTOM_CLAIMS, e.getMessage());
+        }
+    }
+
     private Map<String, Object> getGoogleUserInfoAndTokens(String code) {
         try {
             // Google Token 추출
@@ -127,6 +135,9 @@ public class AuthService {
         member.setSuperAccount(superAccount);
         memberRepository.save(member);
 
+        Map<String, Object> customClaims = Map.of("superAccountUids", superAccount.getMemberUids());
+        setCustomUidClaims(member.getUid(), customClaims);
+
         constructAndRedirect(response, customToken, member.getDisplayName(), member.getProfileImageUrl(), member.getEmail());
     }
 
@@ -147,6 +158,9 @@ public class AuthService {
         superAccount.getMembers().add(newMember);
         superAccount.getMemberUids().add(newMember.getUid());
         superAccountRepository.save(superAccount);
+
+        Map<String, Object> customClaims = Map.of("superAccountUids", superAccount.getMemberUids());
+        setCustomUidClaims(superAccountUid, customClaims);
 
         constructAndRedirect(response, customToken, newMember.getDisplayName(), newMember.getProfileImageUrl(), newMember.getEmail());
     }

--- a/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
+++ b/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
@@ -18,6 +18,8 @@ public enum ErrorCode {
     NOT_FOUND_FIREBASE_SERVICE_ACCOUNT_KEY(404, "Not found Firebase SDK file"),
     FIREBASE_CLOUD_MESSAGING_SEND_ERR(500, "FCM(Firebase Cloud Messaging) Send Error"),
     NOT_FOUND_FIREBASE_CLOUD_MESSAGING_TOKEN_ERR(404, "Not Found FCM Token"),
+    FAILED_TO_CREATE_CUSTOM_TOKEN(500, "Failed to create custom token"),
+    FAILED_TO_SET_CUSTOM_CLAIMS(500, "Failed to set custom claims"),
 
     // member
     NOT_FOUND_MEMBER_ERROR_MESSAGE(404, "Not found: Member"),
@@ -33,7 +35,6 @@ public enum ErrorCode {
     // token
     NOT_FOUND_ACCESS_TOKEN(404, "Not found: Access Token"),
     NOT_FOUND_REFRESH_TOKEN(404, "Not found: Refresh Token"),
-    FAILED_TO_CREATE_CUSTOM_TOKEN(500, "Failed to create custom token"),
     FAILED_TO_VERIFY_ID_TOKEN(500, "failed to verify Id Token"),
 
     // email


### PR DESCRIPTION
## 설명
- Firebase Custom Claims는 인증된 사용자의 ID 토큰에 사용자 정의 정보를 추가하는 기능을 제공합니다. 
- 이를 통해 사용자 역할, 그룹 정보 등의 커스텀 데이터를 저장하고 클라이언트 애플리케이션에서 이를 활용할 수 있습니다.
- Auth 시 SignIn, addAccount 메서드 때 해당 Firebase Custom Token에 Custom Claims로 해당 계정의 uid 값들의 묶음을 추가합니다.

## 완료한 기능 명세
- [x] setCustomClaims

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

