### PR TITLE
[FEAT] Team, Invitation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+	implementation 'org.mongodb:mongodb-driver-sync:5.1.2'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/woozlabs/echo/domain/member/entity/Member.java
+++ b/src/main/java/woozlabs/echo/domain/member/entity/Member.java
@@ -5,11 +5,13 @@ import lombok.*;
 import woozlabs.echo.domain.echo.entity.EmailTemplate;
 import woozlabs.echo.domain.contactGroup.entity.MemberContactGroup;
 import woozlabs.echo.domain.echo.entity.UserSidebarConfig;
+import woozlabs.echo.domain.signature.Signature;
 import woozlabs.echo.global.common.entity.BaseEntity;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -47,4 +49,13 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<MemberContactGroup> memberContactGroups = new ArrayList<>();
+
+    @OneToMany(mappedBy = "ownerId", cascade = CascadeType.ALL)
+    private List<Signature> allSignatures = new ArrayList<>();
+
+    public List<Signature> getSignatures() {
+        return allSignatures.stream()
+                .filter(signature -> signature.getType() == Signature.SignatureType.MEMBER)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/woozlabs/echo/domain/signature/Signature.java
+++ b/src/main/java/woozlabs/echo/domain/signature/Signature.java
@@ -1,0 +1,28 @@
+package woozlabs.echo.domain.signature;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import woozlabs.echo.global.common.entity.BaseEntity;
+
+@Entity
+@Getter
+public class Signature extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Lob
+    private String content;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private SignatureType type;
+
+    @Column(name = "owner_id")
+    private Long ownerId; // teamId or memberId
+
+    public enum SignatureType {
+        MEMBER, TEAM
+    }
+}

--- a/src/main/java/woozlabs/echo/domain/team/controller/TeamController.java
+++ b/src/main/java/woozlabs/echo/domain/team/controller/TeamController.java
@@ -42,4 +42,12 @@ public class TeamController {
         teamService.inviteToTeam(uid, teamId, requestDto);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/invite/accept")
+    public ResponseEntity<Void> acceptInvitation(HttpServletRequest httpServletRequest,
+                                                 @RequestParam String token) {
+        String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
+        teamService.acceptInvitation(uid, token);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/woozlabs/echo/domain/team/controller/TeamController.java
+++ b/src/main/java/woozlabs/echo/domain/team/controller/TeamController.java
@@ -1,0 +1,35 @@
+package woozlabs.echo.domain.team.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import woozlabs.echo.domain.team.dto.CreateTeamRequestDto;
+import woozlabs.echo.domain.team.dto.TeamResponseDto;
+import woozlabs.echo.domain.team.service.TeamService;
+import woozlabs.echo.global.constant.GlobalConstant;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/echo")
+@RequiredArgsConstructor
+public class TeamController {
+
+    private final TeamService teamService;
+
+    @GetMapping("/teams")
+    public ResponseEntity<List<TeamResponseDto>> getTeams(HttpServletRequest httpServletRequest) {
+        String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
+        List<TeamResponseDto> teams = teamService.getTeams(uid);
+        return ResponseEntity.ok(teams);
+    }
+
+    @PostMapping("/team")
+    public ResponseEntity<Void> createTeam(HttpServletRequest httpServletRequest,
+                                           @RequestBody CreateTeamRequestDto createTeamRequestDto) {
+        String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
+        teamService.createTeam(uid, createTeamRequestDto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/woozlabs/echo/domain/team/controller/TeamController.java
+++ b/src/main/java/woozlabs/echo/domain/team/controller/TeamController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import woozlabs.echo.domain.team.dto.CreateTeamRequestDto;
+import woozlabs.echo.domain.team.dto.TeamInvitationRequestDto;
 import woozlabs.echo.domain.team.dto.TeamResponseDto;
 import woozlabs.echo.domain.team.service.TeamService;
 import woozlabs.echo.global.constant.GlobalConstant;
@@ -30,6 +31,15 @@ public class TeamController {
                                            @RequestBody CreateTeamRequestDto createTeamRequestDto) {
         String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
         teamService.createTeam(uid, createTeamRequestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{teamId}/invite")
+    public ResponseEntity<Void> inviteToTeam(HttpServletRequest httpServletRequest,
+                                             @PathVariable("teamId") Long teamId,
+                                             @RequestBody TeamInvitationRequestDto requestDto) {
+        String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
+        teamService.inviteToTeam(uid, teamId, requestDto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/woozlabs/echo/domain/team/controller/TeamController.java
+++ b/src/main/java/woozlabs/echo/domain/team/controller/TeamController.java
@@ -34,7 +34,7 @@ public class TeamController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/{teamId}/invite")
+    @PostMapping("/team/{teamId}/invite")
     public ResponseEntity<Void> inviteToTeam(HttpServletRequest httpServletRequest,
                                              @PathVariable("teamId") Long teamId,
                                              @RequestBody TeamInvitationRequestDto requestDto) {

--- a/src/main/java/woozlabs/echo/domain/team/dto/CreateTeamRequestDto.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/CreateTeamRequestDto.java
@@ -1,0 +1,11 @@
+package woozlabs.echo.domain.team.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateTeamRequestDto {
+
+    private String name;
+}

--- a/src/main/java/woozlabs/echo/domain/team/dto/SendInvitationEmailDto.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/SendInvitationEmailDto.java
@@ -10,7 +10,13 @@ import lombok.Setter;
 public class SendInvitationEmailDto {
 
     private String to;
-    private String inviterName;
+    private String username;
+    private String userImage;
+    private String invitedByUsername;
+    private String invitedByEmail;
     private String teamName;
-    private String invitationLink;
+    private String teamImage;
+    private String inviteLink;
+    private String inviteFromIp;
+    private String inviteFromLocation;
 }

--- a/src/main/java/woozlabs/echo/domain/team/dto/SendInvitationEmailDto.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/SendInvitationEmailDto.java
@@ -1,0 +1,16 @@
+package woozlabs.echo.domain.team.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class SendInvitationEmailDto {
+
+    private String to;
+    private String inviterName;
+    private String teamName;
+    private String invitationLink;
+}

--- a/src/main/java/woozlabs/echo/domain/team/dto/TeamInvitationRequestDto.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/TeamInvitationRequestDto.java
@@ -1,11 +1,12 @@
 package woozlabs.echo.domain.team.dto;
 
 import lombok.Getter;
+import woozlabs.echo.domain.team.entity.Role;
 import woozlabs.echo.domain.team.entity.TeamInvitation;
 
 @Getter
 public class TeamInvitationRequestDto {
 
     private String inviteeEmail;
-    private TeamInvitation.InviteeRole inviteeRole;
+    private Role inviteeRole;
 }

--- a/src/main/java/woozlabs/echo/domain/team/dto/TeamInvitationRequestDto.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/TeamInvitationRequestDto.java
@@ -1,0 +1,11 @@
+package woozlabs.echo.domain.team.dto;
+
+import lombok.Getter;
+import woozlabs.echo.domain.team.entity.TeamInvitation;
+
+@Getter
+public class TeamInvitationRequestDto {
+
+    private String inviteeEmail;
+    private TeamInvitation.InviteeRole inviteeRole;
+}

--- a/src/main/java/woozlabs/echo/domain/team/dto/TeamMemberDto.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/TeamMemberDto.java
@@ -1,0 +1,13 @@
+package woozlabs.echo.domain.team.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import woozlabs.echo.domain.team.entity.TeamMember;
+
+@Getter
+@Builder
+public class TeamMemberDto {
+    private Long id;
+    private String memberUid;
+    private TeamMember.TeamMemberRole role;
+}

--- a/src/main/java/woozlabs/echo/domain/team/dto/TeamMemberDto.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/TeamMemberDto.java
@@ -2,6 +2,7 @@ package woozlabs.echo.domain.team.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import woozlabs.echo.domain.team.entity.Role;
 import woozlabs.echo.domain.team.entity.TeamMember;
 
 @Getter
@@ -9,5 +10,5 @@ import woozlabs.echo.domain.team.entity.TeamMember;
 public class TeamMemberDto {
     private Long id;
     private String memberUid;
-    private TeamMember.TeamMemberRole role;
+    private Role role;
 }

--- a/src/main/java/woozlabs/echo/domain/team/dto/TeamResponseDto.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/TeamResponseDto.java
@@ -1,7 +1,9 @@
 package woozlabs.echo.domain.team.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import woozlabs.echo.domain.team.entity.Team;
 import woozlabs.echo.domain.team.entity.TeamMember;
 
@@ -9,6 +11,8 @@ import java.util.List;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class TeamResponseDto {
 
     private Long id;

--- a/src/main/java/woozlabs/echo/domain/team/dto/TeamResponseDto.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/TeamResponseDto.java
@@ -1,0 +1,25 @@
+package woozlabs.echo.domain.team.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import woozlabs.echo.domain.team.entity.Team;
+import woozlabs.echo.domain.team.entity.TeamMember;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class TeamResponseDto {
+
+    private Long id;
+    private String name;
+    private String creatorUid;
+    private List<TeamMember> teamMembers;
+
+    public TeamResponseDto(Team team) {
+        this.id = team.getId();
+        this.name = team.getName();
+        this.creatorUid = team.getCreator().getUid();
+        this.teamMembers = team.getTeamMembers();
+    }
+}

--- a/src/main/java/woozlabs/echo/domain/team/entity/PrivateComment.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/PrivateComment.java
@@ -1,0 +1,20 @@
+package woozlabs.echo.domain.team.entity;
+
+import jakarta.persistence.Id;
+import lombok.Getter;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Document(collection = "private_comments")
+public class PrivateComment {
+
+    @Id
+    private String id;
+
+    private String sharedEmailId;  // MongoDB의 SharedEmail 문서 ID 참조
+    private String memberId;  // MySQL의 Member 엔티티 ID 참조
+    private String content;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/woozlabs/echo/domain/team/entity/Role.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/Role.java
@@ -1,0 +1,6 @@
+package woozlabs.echo.domain.team.entity;
+
+public enum Role {
+
+    ADMIN, EDITOR, VIEWER
+}

--- a/src/main/java/woozlabs/echo/domain/team/entity/SharedEmail.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/SharedEmail.java
@@ -1,0 +1,23 @@
+package woozlabs.echo.domain.team.entity;
+
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Document(collection = "shared_emails")
+public class SharedEmail {
+
+    @Id
+    private String id;
+    private String teamId;  // MySQL의 Team 엔티티 ID 참조
+    private String threadId;
+    private String subject;
+    private String sharedById;  // MySQL의 Member 엔티티 ID 참조
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/woozlabs/echo/domain/team/entity/Team.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/Team.java
@@ -1,7 +1,10 @@
 package woozlabs.echo.domain.team.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import woozlabs.echo.domain.member.entity.Member;
 import woozlabs.echo.domain.signature.Signature;
 import woozlabs.echo.global.common.entity.BaseEntity;
@@ -12,6 +15,7 @@ import java.util.stream.Collectors;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Team extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,5 +35,16 @@ public class Team extends BaseEntity {
         return allSignatures.stream()
                 .filter(signature -> signature.getType() == Signature.SignatureType.TEAM)
                 .collect(Collectors.toList());
+    }
+
+    @Builder
+    public Team(String name, Member creator) {
+        this.name = name;
+        this.creator = creator;
+    }
+
+    public void addTeamMember(TeamMember teamMember) {
+        this.teamMembers.add(teamMember);
+        teamMember.setTeam(this);
     }
 }

--- a/src/main/java/woozlabs/echo/domain/team/entity/Team.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/Team.java
@@ -1,0 +1,35 @@
+package woozlabs.echo.domain.team.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import woozlabs.echo.domain.member.entity.Member;
+import woozlabs.echo.domain.signature.Signature;
+import woozlabs.echo.global.common.entity.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Entity
+@Getter
+public class Team extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member creator;
+
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)
+    private List<TeamMember> teamMembers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "ownerId", cascade = CascadeType.ALL)
+    private List<Signature> allSignatures = new ArrayList<>();
+
+    public List<Signature> getSignatureType() {
+        return allSignatures.stream()
+                .filter(signature -> signature.getType() == Signature.SignatureType.TEAM)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/woozlabs/echo/domain/team/entity/TeamInvitation.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/TeamInvitation.java
@@ -50,6 +50,10 @@ public class TeamInvitation {
         this.deleted = true;
     }
 
+    public void setStatus(InvitationStatus status) {
+        this.status = status;
+    }
+
     @Builder
     public TeamInvitation(Team team, Member inviter, String inviteeEmail, String token, LocalDateTime expiresAt, LocalDateTime sentAt, Role inviteeRole) {
         this.team = team;

--- a/src/main/java/woozlabs/echo/domain/team/entity/TeamInvitation.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/TeamInvitation.java
@@ -1,0 +1,40 @@
+package woozlabs.echo.domain.team.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import woozlabs.echo.domain.member.entity.Member;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+public class TeamInvitation {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inviter_id")
+    private Member inviter;
+
+    private String inviteeEmail;
+
+    @Enumerated(EnumType.STRING)
+    private InvitationStatus status;
+
+    private String token;
+    private LocalDateTime expiresAt;
+    private LocalDateTime sentAt;
+
+    public enum InvitationStatus {
+        PENDING, ACCEPTED, REJECTED, EXPIRED
+    }
+
+    public enum InviteeRole {
+        ADMIN, EDITOR, VIEWER
+    }
+}

--- a/src/main/java/woozlabs/echo/domain/team/entity/TeamInvitation.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/TeamInvitation.java
@@ -1,13 +1,17 @@
 package woozlabs.echo.domain.team.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import woozlabs.echo.domain.member.entity.Member;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TeamInvitation {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,6 +30,9 @@ public class TeamInvitation {
     @Enumerated(EnumType.STRING)
     private InvitationStatus status;
 
+    @Enumerated(EnumType.STRING)
+    private InviteeRole role;
+
     private String token;
     private LocalDateTime expiresAt;
     private LocalDateTime sentAt;
@@ -34,7 +41,23 @@ public class TeamInvitation {
         PENDING, ACCEPTED, REJECTED, EXPIRED
     }
 
+    public void accept() {
+        this.status = InvitationStatus.ACCEPTED;
+    }
+
     public enum InviteeRole {
         ADMIN, EDITOR, VIEWER
+    }
+
+    @Builder
+    public TeamInvitation(Team team, Member inviter, String inviteeEmail, String token, LocalDateTime expiresAt, LocalDateTime sentAt, InviteeRole inviteeRole) {
+        this.team = team;
+        this.inviter = inviter;
+        this.inviteeEmail = inviteeEmail;
+        this.status = InvitationStatus.PENDING;
+        this.token = token;
+        this.expiresAt = expiresAt;
+        this.sentAt = sentAt;
+        this.role = inviteeRole;
     }
 }

--- a/src/main/java/woozlabs/echo/domain/team/entity/TeamInvitation.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/TeamInvitation.java
@@ -31,11 +31,12 @@ public class TeamInvitation {
     private InvitationStatus status;
 
     @Enumerated(EnumType.STRING)
-    private InviteeRole role;
+    private Role role;
 
     private String token;
     private LocalDateTime expiresAt;
     private LocalDateTime sentAt;
+    private boolean deleted = Boolean.FALSE;
 
     public enum InvitationStatus {
         PENDING, ACCEPTED, REJECTED, EXPIRED
@@ -45,12 +46,12 @@ public class TeamInvitation {
         this.status = InvitationStatus.ACCEPTED;
     }
 
-    public enum InviteeRole {
-        ADMIN, EDITOR, VIEWER
+    public void softDelete() {
+        this.deleted = true;
     }
 
     @Builder
-    public TeamInvitation(Team team, Member inviter, String inviteeEmail, String token, LocalDateTime expiresAt, LocalDateTime sentAt, InviteeRole inviteeRole) {
+    public TeamInvitation(Team team, Member inviter, String inviteeEmail, String token, LocalDateTime expiresAt, LocalDateTime sentAt, Role inviteeRole) {
         this.team = team;
         this.inviter = inviter;
         this.inviteeEmail = inviteeEmail;

--- a/src/main/java/woozlabs/echo/domain/team/entity/TeamMember.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/TeamMember.java
@@ -22,14 +22,10 @@ public class TeamMember {
     private Member member;
 
     @Enumerated(EnumType.STRING)
-    private TeamMemberRole role;
-
-    public enum TeamMemberRole {
-        ADMIN, EDITOR, VIEWER
-    }
+    private Role role;
 
     @Builder
-    public TeamMember(Team team, Member member, TeamMemberRole role) {
+    public TeamMember(Team team, Member member, Role role) {
         this.team = team;
         this.member = member;
         this.role = role;

--- a/src/main/java/woozlabs/echo/domain/team/entity/TeamMember.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/TeamMember.java
@@ -1,0 +1,29 @@
+package woozlabs.echo.domain.team.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import woozlabs.echo.domain.member.entity.Member;
+
+@Entity
+@Getter
+public class TeamMember {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
+
+    @Enumerated(EnumType.STRING)
+    private TeamMemberRole role;
+
+    public enum TeamMemberRole {
+        ADMIN, EDITOR, VIEWER
+    }
+}
+

--- a/src/main/java/woozlabs/echo/domain/team/entity/TeamMember.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/TeamMember.java
@@ -1,29 +1,38 @@
 package woozlabs.echo.domain.team.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 import woozlabs.echo.domain.member.entity.Member;
 
 @Entity
 @Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TeamMember {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id")
     private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     @Enumerated(EnumType.STRING)
     private TeamMemberRole role;
 
     public enum TeamMemberRole {
         ADMIN, EDITOR, VIEWER
+    }
+
+    @Builder
+    public TeamMember(Team team, Member member, TeamMemberRole role) {
+        this.team = team;
+        this.member = member;
+        this.role = role;
     }
 }
 

--- a/src/main/java/woozlabs/echo/domain/team/repository/SharedEmailRepository.java
+++ b/src/main/java/woozlabs/echo/domain/team/repository/SharedEmailRepository.java
@@ -1,0 +1,7 @@
+package woozlabs.echo.domain.team.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import woozlabs.echo.domain.team.entity.SharedEmail;
+
+public interface SharedEmailRepository extends MongoRepository<SharedEmail, String> {
+}

--- a/src/main/java/woozlabs/echo/domain/team/repository/TeamInvitationRepository.java
+++ b/src/main/java/woozlabs/echo/domain/team/repository/TeamInvitationRepository.java
@@ -3,5 +3,9 @@ package woozlabs.echo.domain.team.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import woozlabs.echo.domain.team.entity.TeamInvitation;
 
+import java.util.Optional;
+
 public interface TeamInvitationRepository extends JpaRepository<TeamInvitation, Long> {
+
+    Optional<TeamInvitation> findByToken(String token);
 }

--- a/src/main/java/woozlabs/echo/domain/team/repository/TeamInvitationRepository.java
+++ b/src/main/java/woozlabs/echo/domain/team/repository/TeamInvitationRepository.java
@@ -1,0 +1,7 @@
+package woozlabs.echo.domain.team.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import woozlabs.echo.domain.team.entity.TeamInvitation;
+
+public interface TeamInvitationRepository extends JpaRepository<TeamInvitation, Long> {
+}

--- a/src/main/java/woozlabs/echo/domain/team/repository/TeamInvitationRepository.java
+++ b/src/main/java/woozlabs/echo/domain/team/repository/TeamInvitationRepository.java
@@ -1,11 +1,18 @@
 package woozlabs.echo.domain.team.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import woozlabs.echo.domain.team.entity.TeamInvitation;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface TeamInvitationRepository extends JpaRepository<TeamInvitation, Long> {
 
     Optional<TeamInvitation> findByToken(String token);
+
+    @Query("SELECT ti FROM TeamInvitation ti WHERE ti.expiresAt <= :now AND ti.status = 'PENDING' AND ti.deleted = false")
+    List<TeamInvitation> findExpiredInvitations(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/woozlabs/echo/domain/team/repository/TeamRepository.java
+++ b/src/main/java/woozlabs/echo/domain/team/repository/TeamRepository.java
@@ -1,0 +1,7 @@
+package woozlabs.echo.domain.team.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import woozlabs.echo.domain.team.entity.Team;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+}

--- a/src/main/java/woozlabs/echo/domain/team/repository/TeamRepository.java
+++ b/src/main/java/woozlabs/echo/domain/team/repository/TeamRepository.java
@@ -1,7 +1,14 @@
 package woozlabs.echo.domain.team.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import woozlabs.echo.domain.team.entity.Team;
 
+import java.util.List;
+
 public interface TeamRepository extends JpaRepository<Team, Long> {
+
+    @Query("SELECT t FROM Team t JOIN t.teamMembers tm WHERE tm.member.uid = :memberUid")
+    List<Team> findAllTeamsByMemberUid(@Param("memberUid") String memberUid);
 }

--- a/src/main/java/woozlabs/echo/domain/team/service/EmailService.java
+++ b/src/main/java/woozlabs/echo/domain/team/service/EmailService.java
@@ -1,23 +1,52 @@
 package woozlabs.echo.domain.team.service;
 
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
 import woozlabs.echo.domain.team.dto.SendInvitationEmailDto;
+import woozlabs.echo.global.exception.CustomErrorException;
+import woozlabs.echo.global.exception.ErrorCode;
 
 @Service
 @RequiredArgsConstructor
 public class EmailService {
 
     private final JavaMailSender javaMailSender;
+    private final TemplateEngine templateEngine;
 
     public void sendInvitationEmail(SendInvitationEmailDto sendInvitationEmailDto) {
-        SimpleMailMessage message = new SimpleMailMessage();
+        MimeMessage message = javaMailSender.createMimeMessage();
 
-        message.setTo(sendInvitationEmailDto.getTo());
-        message.setSubject(sendInvitationEmailDto.getInviterName() + "님이 " + sendInvitationEmailDto.getTeamName() + " 팀에 초대했습니다.");
-        message.setText("팀에 참여하려면 다음 링크를 클릭하세요: " + sendInvitationEmailDto.getInvitationLink());
-        javaMailSender.send(message);
+        try {
+            MimeMessageHelper messageHelper = new MimeMessageHelper(message, true, "UTF-8");
+            messageHelper.setTo(sendInvitationEmailDto.getTo());
+            messageHelper.setSubject(sendInvitationEmailDto.getInvitedByUsername() + "님이 나를 " +
+                    sendInvitationEmailDto.getTeamName() + " 워크스페이스에 초대했습니다");
+            messageHelper.setText(getHtmlContent(sendInvitationEmailDto), true);
+
+            javaMailSender.send(message);
+        } catch (MessagingException e) {
+            throw new CustomErrorException(ErrorCode.FAILED_TO_INVITATION_MAIL, e.getMessage());
+        }
+    }
+
+    private String getHtmlContent(SendInvitationEmailDto dto) {
+        Context context = new Context();
+        context.setVariable("username", dto.getUsername());
+        context.setVariable("userImage", dto.getUserImage());
+        context.setVariable("invitedByUsername", dto.getInvitedByUsername());
+        context.setVariable("invitedByEmail", dto.getInvitedByEmail());
+        context.setVariable("teamName", dto.getTeamName());
+        context.setVariable("teamImage", dto.getTeamImage());
+        context.setVariable("inviteLink", dto.getInviteLink());
+        context.setVariable("inviteFromIp", dto.getInviteFromIp());
+        context.setVariable("inviteFromLocation", dto.getInviteFromLocation());
+
+        return templateEngine.process("invite-email", context);
     }
 }

--- a/src/main/java/woozlabs/echo/domain/team/service/EmailService.java
+++ b/src/main/java/woozlabs/echo/domain/team/service/EmailService.java
@@ -5,6 +5,7 @@ import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
@@ -19,6 +20,7 @@ public class EmailService {
     private final JavaMailSender javaMailSender;
     private final TemplateEngine templateEngine;
 
+    @Async
     public void sendInvitationEmail(SendInvitationEmailDto sendInvitationEmailDto) {
         MimeMessage message = javaMailSender.createMimeMessage();
 

--- a/src/main/java/woozlabs/echo/domain/team/service/EmailService.java
+++ b/src/main/java/woozlabs/echo/domain/team/service/EmailService.java
@@ -1,0 +1,23 @@
+package woozlabs.echo.domain.team.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import woozlabs.echo.domain.team.dto.SendInvitationEmailDto;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender javaMailSender;
+
+    public void sendInvitationEmail(SendInvitationEmailDto sendInvitationEmailDto) {
+        SimpleMailMessage message = new SimpleMailMessage();
+
+        message.setTo(sendInvitationEmailDto.getTo());
+        message.setSubject(sendInvitationEmailDto.getInviterName() + "님이 " + sendInvitationEmailDto.getTeamName() + " 팀에 초대했습니다.");
+        message.setText("팀에 참여하려면 다음 링크를 클릭하세요: " + sendInvitationEmailDto.getInvitationLink());
+        javaMailSender.send(message);
+    }
+}

--- a/src/main/java/woozlabs/echo/domain/team/service/SharedEmailService.java
+++ b/src/main/java/woozlabs/echo/domain/team/service/SharedEmailService.java
@@ -1,0 +1,9 @@
+package woozlabs.echo.domain.team.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SharedEmailService {
+}

--- a/src/main/java/woozlabs/echo/domain/team/service/TeamService.java
+++ b/src/main/java/woozlabs/echo/domain/team/service/TeamService.java
@@ -2,8 +2,53 @@ package woozlabs.echo.domain.team.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import woozlabs.echo.domain.member.entity.Member;
+import woozlabs.echo.domain.member.repository.MemberRepository;
+import woozlabs.echo.domain.team.dto.CreateTeamRequestDto;
+import woozlabs.echo.domain.team.dto.TeamResponseDto;
+import woozlabs.echo.domain.team.entity.Team;
+import woozlabs.echo.domain.team.entity.TeamMember;
+import woozlabs.echo.domain.team.repository.TeamRepository;
+import woozlabs.echo.global.exception.CustomErrorException;
+import woozlabs.echo.global.exception.ErrorCode;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class TeamService {
+
+    private final TeamRepository teamRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void createTeam(String uid, CreateTeamRequestDto createTeamRequestDto) {
+        Member creator = memberRepository.findByUid(uid)
+                .orElseThrow(() -> new CustomErrorException(ErrorCode.NOT_FOUND_MEMBER_ERROR_MESSAGE));
+
+        Team team = Team.builder()
+                .name(createTeamRequestDto.getName())
+                .creator(creator)
+                .build();
+
+        TeamMember creatorMember = TeamMember.builder()
+                .team(team)
+                .member(creator)
+                .role(TeamMember.TeamMemberRole.ADMIN)
+                .build();
+
+        team.addTeamMember(creatorMember);
+        teamRepository.save(team);
+    }
+
+    public List<TeamResponseDto> getTeams(String uid) {
+        List<Team> teams = teamRepository.findAllTeamsByMemberUid(uid);
+
+        return teams.stream()
+                .map(TeamResponseDto::new)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/woozlabs/echo/domain/team/service/TeamService.java
+++ b/src/main/java/woozlabs/echo/domain/team/service/TeamService.java
@@ -88,9 +88,15 @@ public class TeamService {
 
         SendInvitationEmailDto sendInvitationEmailDto = SendInvitationEmailDto.builder()
                 .to(requestDto.getInviteeEmail())
-                .inviterName(inviter.getDisplayName())
+                .username(requestDto.getInviteeEmail())
+                .userImage("https://vercel.com/static/vercel-user.png") // mock
+                .invitedByUsername(inviter.getDisplayName())
+                .invitedByEmail(inviter.getEmail())
                 .teamName(team.getName())
-                .invitationLink(invitationLink)
+                .teamImage("https://vercel.com/static/vercel-team.png") // mock
+                .inviteLink(invitationLink)
+                .inviteFromIp("192.168.1.1")
+                .inviteFromLocation("Seoul, Korea")
                 .build();
 
         emailService.sendInvitationEmail(sendInvitationEmailDto);

--- a/src/main/java/woozlabs/echo/domain/team/service/TeamService.java
+++ b/src/main/java/woozlabs/echo/domain/team/service/TeamService.java
@@ -6,14 +6,21 @@ import org.springframework.transaction.annotation.Transactional;
 import woozlabs.echo.domain.member.entity.Member;
 import woozlabs.echo.domain.member.repository.MemberRepository;
 import woozlabs.echo.domain.team.dto.CreateTeamRequestDto;
+import woozlabs.echo.domain.team.dto.SendInvitationEmailDto;
+import woozlabs.echo.domain.team.dto.TeamInvitationRequestDto;
 import woozlabs.echo.domain.team.dto.TeamResponseDto;
 import woozlabs.echo.domain.team.entity.Team;
+import woozlabs.echo.domain.team.entity.TeamInvitation;
 import woozlabs.echo.domain.team.entity.TeamMember;
+import woozlabs.echo.domain.team.repository.TeamInvitationRepository;
 import woozlabs.echo.domain.team.repository.TeamRepository;
+import woozlabs.echo.global.constant.GlobalConstant;
 import woozlabs.echo.global.exception.CustomErrorException;
 import woozlabs.echo.global.exception.ErrorCode;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -23,6 +30,16 @@ public class TeamService {
 
     private final TeamRepository teamRepository;
     private final MemberRepository memberRepository;
+    private final TeamInvitationRepository teamInvitationRepository;
+    private final EmailService emailService;
+
+    public List<TeamResponseDto> getTeams(String uid) {
+        List<Team> teams = teamRepository.findAllTeamsByMemberUid(uid);
+
+        return teams.stream()
+                .map(TeamResponseDto::new)
+                .collect(Collectors.toList());
+    }
 
     @Transactional
     public void createTeam(String uid, CreateTeamRequestDto createTeamRequestDto) {
@@ -44,11 +61,38 @@ public class TeamService {
         teamRepository.save(team);
     }
 
-    public List<TeamResponseDto> getTeams(String uid) {
-        List<Team> teams = teamRepository.findAllTeamsByMemberUid(uid);
+    @Transactional
+    public void inviteToTeam(String inviterUid, Long teamId, TeamInvitationRequestDto requestDto) {
+        Member inviter = memberRepository.findByUid(inviterUid)
+                .orElseThrow(() -> new CustomErrorException(ErrorCode.NOT_FOUND_MEMBER_ERROR_MESSAGE));
 
-        return teams.stream()
-                .map(TeamResponseDto::new)
-                .collect(Collectors.toList());
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new CustomErrorException(ErrorCode.NOT_FOUND_TEAM));
+
+        String token = UUID.randomUUID().toString();
+        LocalDateTime expiresAt = LocalDateTime.now().plusDays(7);  // 7일 후 만료
+
+        TeamInvitation invitation = TeamInvitation.builder()
+                .team(team)
+                .inviter(inviter)
+                .inviteeEmail(requestDto.getInviteeEmail())
+                .token(token)
+                .expiresAt(expiresAt)
+                .sentAt(LocalDateTime.now())
+                .inviteeRole(requestDto.getInviteeRole())
+                .build();
+
+        teamInvitationRepository.save(invitation);
+
+        String invitationLink = GlobalConstant.ECHO_NEXT_APP_DOMAIN + "/invite?token=" + token;
+
+        SendInvitationEmailDto sendInvitationEmailDto = SendInvitationEmailDto.builder()
+                .to(requestDto.getInviteeEmail())
+                .inviterName(inviter.getDisplayName())
+                .teamName(team.getName())
+                .invitationLink(invitationLink)
+                .build();
+
+        emailService.sendInvitationEmail(sendInvitationEmailDto);
     }
 }

--- a/src/main/java/woozlabs/echo/domain/team/service/TeamService.java
+++ b/src/main/java/woozlabs/echo/domain/team/service/TeamService.java
@@ -1,0 +1,9 @@
+package woozlabs.echo.domain.team.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TeamService {
+}

--- a/src/main/java/woozlabs/echo/global/config/MongoConfig.java
+++ b/src/main/java/woozlabs/echo/global/config/MongoConfig.java
@@ -1,13 +1,24 @@
 package woozlabs.echo.global.config;
 
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
 
 @Configuration
 public class MongoConfig extends AbstractMongoClientConfiguration {
 
+    @Value("${spring.data.mongodb.uri}")
+    private String mongoUri;
+
     @Override
     protected String getDatabaseName() {
         return "echo_mongo";
+    }
+
+    @Override
+    public MongoClient mongoClient() {
+        return MongoClients.create(mongoUri);
     }
 }

--- a/src/main/java/woozlabs/echo/global/config/MongoConfig.java
+++ b/src/main/java/woozlabs/echo/global/config/MongoConfig.java
@@ -1,0 +1,13 @@
+package woozlabs.echo.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+
+@Configuration
+public class MongoConfig extends AbstractMongoClientConfiguration {
+
+    @Override
+    protected String getDatabaseName() {
+        return "echo_mongo";
+    }
+}

--- a/src/main/java/woozlabs/echo/global/constant/GlobalConstant.java
+++ b/src/main/java/woozlabs/echo/global/constant/GlobalConstant.java
@@ -9,6 +9,7 @@ public final class GlobalConstant {
     public static final String AUTH_SIGN_IN_DOMAIN = "https://echo-homepage.vercel.app/sign-in";
     // End Points
     public static final String FE_HOST_ADDRESS = "http://127.0.0.1:3000";
+    public static final String ECHO_NEXT_APP_DOMAIN = "https://echo-homepage.vercel.app";
     // Basic Char
     public static final String SPACE_CHAR = " ";
     public static final String EMPTY_CHAR = "";

--- a/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
+++ b/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
@@ -80,6 +80,7 @@ public enum ErrorCode {
 
     // team
     NOT_FOUND_TEAM(404, "Not Found: Team"),
+    FAILED_TO_INVITATION_MAIL(500, "Failed to send email"),
 
     // verification
     KEYWORD_IO_EXCEPTION(500, "I/O Exception finding verification keywords"),

--- a/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
+++ b/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
@@ -81,6 +81,8 @@ public enum ErrorCode {
     // team
     NOT_FOUND_TEAM(404, "Not Found: Team"),
     FAILED_TO_INVITATION_MAIL(500, "Failed to send email"),
+    NOT_FOUND_INVITATION_TOKEN(404, "Not Found: Invitation Token"),
+    INVITATION_EXPIRED(400, "The team invitation approval deadline has expired"),
 
     // verification
     KEYWORD_IO_EXCEPTION(500, "I/O Exception finding verification keywords"),

--- a/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
+++ b/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
@@ -78,6 +78,9 @@ public enum ErrorCode {
     NOT_FOUND_ORGANIZATION(404, "Not Found: Organization"),
     NOT_FOUND_CONTACT_GROUP(404, "Not Found: Contact Group"),
 
+    // team
+    NOT_FOUND_TEAM(404, "Not Found: Team"),
+
     // verification
     KEYWORD_IO_EXCEPTION(500, "I/O Exception finding verification keywords"),
     EXTRACT_VERIFICATION_LINK_ERR(500, "Extract Verification Link Error"),

--- a/src/main/java/woozlabs/echo/global/scheduler/AccessTokenScheduler.java
+++ b/src/main/java/woozlabs/echo/global/scheduler/AccessTokenScheduler.java
@@ -1,8 +1,9 @@
-package woozlabs.echo.domain.member.service;
+package woozlabs.echo.global.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import woozlabs.echo.domain.member.entity.Member;
@@ -17,10 +18,10 @@ import java.util.List;
 import java.util.Map;
 
 @Slf4j
-@Service
+@Component
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class TokenSchedulerService {
+public class AccessTokenScheduler {
 
     private final MemberRepository memberRepository;
     private final GoogleOAuthUtils googleOAuthUtils;

--- a/src/main/java/woozlabs/echo/global/scheduler/JunkInvitationScheduler.java
+++ b/src/main/java/woozlabs/echo/global/scheduler/JunkInvitationScheduler.java
@@ -1,0 +1,37 @@
+package woozlabs.echo.global.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import woozlabs.echo.domain.team.entity.TeamInvitation;
+import woozlabs.echo.domain.team.repository.TeamInvitationRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JunkInvitationScheduler {
+
+    private final TeamInvitationRepository teamInvitationRepository;
+
+    @Scheduled(cron = "0 0 3 * * ?") // Run every day at 3 AM
+    @Transactional
+    public void removeExpiredInvitations() {
+        LocalDateTime now = LocalDateTime.now();
+        List<TeamInvitation> expiredInvitations = teamInvitationRepository.findExpiredInvitations(now);
+
+        for (TeamInvitation invitation : expiredInvitations) {
+            invitation.softDelete();
+            invitation.setStatus(TeamInvitation.InvitationStatus.EXPIRED);
+        }
+
+        teamInvitationRepository.saveAll(expiredInvitations);
+
+        int removedCount = expiredInvitations.size();
+        log.info("Removed {} expired team invitations", removedCount);
+    }
+}

--- a/src/main/resources/templates/invite-email.html
+++ b/src/main/resources/templates/invite-email.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html dir="ltr" lang="en" xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <meta name="x-apple-disable-message-reformatting" />
+</head>
+<div style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0">Join <span th:text="${invitedByUsername}"></span> on Echo<div> ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿ ‌‏﻿</div>
+</div>
+
+<body style="background-color:rgb(255,255,255);margin-top:auto;margin-bottom:auto;margin-left:auto;margin-right:auto;font-family:ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;;padding-left:0.5rem;padding-right:0.5rem">
+<table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation" style="max-width:465px;border-width:1px;border-style:solid;border-color:rgb(234,234,234);border-radius:0.25rem;margin-top:40px;margin-bottom:40px;margin-left:auto;margin-right:auto;padding:20px">
+    <tbody>
+    <tr style="width:100%">
+        <td>
+            <table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation" style="margin-top:32px">
+                <tbody>
+                <tr>
+                    <td><img alt="Echo" height="37" src="/static/echo-logo.png" style="display:block;outline:none;border:none;text-decoration:none;margin-top:0px;margin-bottom:0px;margin-left:auto;margin-right:auto" width="40" /></td>
+                </tr>
+                </tbody>
+            </table>
+            <h1 style="color:rgb(0,0,0);font-size:24px;font-weight:400;text-align:center;padding:0px;margin-top:30px;margin-bottom:30px;margin-left:0px;margin-right:0px">Join <strong th:text="${teamName}"></strong> on <strong>Echo</strong></h1>
+            <p style="font-size:14px;line-height:24px;margin:16px 0;color:rgb(0,0,0)">Hello <span th:text="${username}"></span>,</p>
+            <p style="font-size:14px;line-height:24px;margin:16px 0;color:rgb(0,0,0)"><strong th:text="${invitedByUsername}"></strong> (<a th:href="'mailto:' + ${invitedByEmail}" style="color:rgb(37,99,235);text-decoration:none;text-decoration-line:none" target="_blank" th:text="${invitedByEmail}"></a>) has invited you to the <strong th:text="${teamName}"></strong> team on <strong>Echo</strong>.</p>
+            <table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation">
+                <tbody>
+                <tr>
+                    <td>
+                        <table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation">
+                            <tbody style="width:100%">
+                            <tr style="width:100%">
+                                <td align="right" data-id="__react-email-column"><img th:src="${userImage}" height="64" style="display:block;outline:none;border:none;text-decoration:none;border-radius:9999px" width="64" /></td>
+                                <td align="center" data-id="__react-email-column"><img alt="invited you to" height="9" src="/static/echo-arrow.png" style="display:block;outline:none;border:none;text-decoration:none" width="12" /></td>
+                                <td align="left" data-id="__react-email-column"><img th:src="${teamImage}" height="64" style="display:block;outline:none;border:none;text-decoration:none;border-radius:9999px" width="64" /></td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+            <table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation" style="text-align:center;margin-top:32px;margin-bottom:32px">
+                <tbody>
+                <tr>
+                    <td><a th:href="${inviteLink}" style="line-height:100%;text-decoration:none;display:inline-block;max-width:100%;background-color:rgb(0,0,0);border-radius:0.25rem;color:rgb(255,255,255);font-size:12px;font-weight:600;text-decoration-line:none;text-align:center;padding-left:1.25rem;padding-right:1.25rem;padding-top:0.75rem;padding-bottom:0.75rem;padding:12px 20px 12px 20px" target="_blank"><span><!--[if mso]><i style="mso-font-width:500%;mso-text-raise:18" hidden>&#8202;&#8202;</i><![endif]--></span><span style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:9px">Join the team</span><span><!--[if mso]><i style="mso-font-width:500%" hidden>&#8202;&#8202;&#8203;</i><![endif]--></span></a></td>
+                </tr>
+                </tbody>
+            </table>
+            <p style="font-size:14px;line-height:24px;margin:16px 0;color:rgb(0,0,0)">or copy and paste this URL into your browser: <a th:href="${inviteLink}" style="color:rgb(37,99,235);text-decoration:none;text-decoration-line:none" target="_blank" th:text="${inviteLink}"></a></p>
+            <hr style="width:100%;border:none;border-top:1px solid #eaeaea;border-width:1px;border-style:solid;border-color:rgb(234,234,234);margin-top:26px;margin-bottom:26px;margin-left:0px;margin-right:0px" />
+            <p style="font-size:12px;line-height:24px;margin:16px 0;color:rgb(102,102,102)">This invitation was intended for <span style="color:rgb(0,0,0)" th:text="${username}"></span>. This invite was sent from <span style="color:rgb(0,0,0)" th:text="${inviteFromIp}"></span> located in <span style="color:rgb(0,0,0)" th:text="${inviteFromLocation}"></span>. If you were not expecting this invitation, you can ignore this email. If you are concerned about your account&#x27;s safety, please reply to this email.</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+
+</html>


### PR DESCRIPTION
## 설명
- close #97
- close #111 

## 완료한 기능 명세
- [x] 기능 파악 후 초안 문서화 정리
- [x] DB 설계
- [x] Entity 작성
- [x] DBMS별로 담을 데이터 분리 설계
- [x] Team CR
- [x] Mail Sender
- [x] Team Invitation
  - [x] Invite
    - [x] MailSender 구현
    - [x] ThymeLeaf 사용해서 초대 Template 구현 후 해당 Template으로 메일 전송
  - [x] Accept
    - [x] 승인 후 invitation soft Delete
  - [x] 만료기한이 지난 Invitation delete Scheduler 구현
- [x] GCP MongoDB Setting (DBaaS 방식)
- [x] Secret Manager - yml 파일 교체

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기

<img width="488" alt="image" src="https://github.com/user-attachments/assets/300e0110-e99a-4abd-a8bc-6304db904d3d">

### 2022년 05월 20일 구글 업데이트
- 외부에서 메일, 비밀번호만으로 요청을 날리는 것이 더이상 지원되지 않게 됨
- 현재 MailSender의 경우 메일과 비밀번호만으로 요청을 날리는 형식이나 위의 방식이 지원되지 않게됨
  - 2차 인증을 걸은 다음 16자리의 앱 키를 등록받아서 해당 앱 키를 비밀번호로 사용하면 추출 가능함
  - 현재 echo.develop 구글 계정은 2차 인증을 못함 @leokim8012 도움 필요
  - 인증 이후 앱 키를 받아서 등록하면 우선적으로 echo 개발 gmail 계정으로 이메일을 날릴 예정

### 메일 전송 시간 단축
평균 5, 6s -> 100ms


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

