### PR TITLE
[FEAT] SharedEmail Inbox

### DIFF
--- a/src/main/java/woozlabs/echo/domain/contactGroup/controller/ContactGroupController.java
+++ b/src/main/java/woozlabs/echo/domain/contactGroup/controller/ContactGroupController.java
@@ -31,7 +31,7 @@ public class ContactGroupController {
         String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
         String contactGroupName = createContactGroupRequest.getName();
         contactGroupService.createContactGroup(uid, contactGroupName);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(201).build();
     }
 
     @PostMapping("/contactGroups/{contactGroupId}/members")

--- a/src/main/java/woozlabs/echo/domain/echo/controller/EmailTemplateController.java
+++ b/src/main/java/woozlabs/echo/domain/echo/controller/EmailTemplateController.java
@@ -42,7 +42,7 @@ public class EmailTemplateController {
         String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
         try {
             emailTemplateService.createTemplate(uid, createEmailTemplateRequest);
-            return ResponseEntity.ok().build();
+            return ResponseEntity.status(201).build();
         } catch (Exception e) {
             log.error("Error occurred while creating email template for user with UID: {}", uid, e);
             throw new CustomErrorException(ErrorCode.FAILED_TO_CREATE_EMAIL_TEMPLATE, e.getMessage());

--- a/src/main/java/woozlabs/echo/domain/team/controller/SharedInboxController.java
+++ b/src/main/java/woozlabs/echo/domain/team/controller/SharedInboxController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import woozlabs.echo.domain.team.dto.ShareEmailRequestDto;
 import woozlabs.echo.domain.team.entity.SharedEmail;
+import woozlabs.echo.domain.team.entity.Thread;
 import woozlabs.echo.domain.team.service.SharedInboxService;
 import woozlabs.echo.global.constant.GlobalConstant;
 
@@ -18,15 +19,24 @@ public class SharedInboxController {
 
     private final SharedInboxService sharedInboxService;
 
-    @GetMapping("/team/{teamId}")
+    @GetMapping("/emails/team/{teamId}")
     public ResponseEntity<List<SharedEmail>> getSharedEmailsByTeam(@PathVariable("teamId") String teamId) {
         List<SharedEmail> allEmails = sharedInboxService.getSharedEmailsByTeam(teamId);
         return ResponseEntity.ok(allEmails);
     }
 
-    @PostMapping("/share")
+    @GetMapping("/thread/{threadId}")
+    public ResponseEntity<Thread> getSharedThread(@PathVariable("threadId") String threadId) {
+        Thread thread = sharedInboxService.getSharedThread(threadId);
+        if (thread == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(thread);
+    }
+
+    @PostMapping("/thread/share")
     public ResponseEntity<Void> shareEmail(HttpServletRequest httpServletRequest,
-                                                  @RequestBody ShareEmailRequestDto shareEmailRequestDto) {
+                                           @RequestBody ShareEmailRequestDto shareEmailRequestDto) {
         String sharedById = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
         sharedInboxService.shareEmail(sharedById, shareEmailRequestDto);
         return ResponseEntity.status(201).build();

--- a/src/main/java/woozlabs/echo/domain/team/controller/SharedInboxController.java
+++ b/src/main/java/woozlabs/echo/domain/team/controller/SharedInboxController.java
@@ -1,0 +1,34 @@
+package woozlabs.echo.domain.team.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import woozlabs.echo.domain.team.dto.ShareEmailRequestDto;
+import woozlabs.echo.domain.team.entity.SharedEmail;
+import woozlabs.echo.domain.team.service.SharedInboxService;
+import woozlabs.echo.global.constant.GlobalConstant;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/echo")
+@RequiredArgsConstructor
+public class SharedInboxController {
+
+    private final SharedInboxService sharedInboxService;
+
+    @GetMapping("/team/{teamId}")
+    public ResponseEntity<List<SharedEmail>> getSharedEmailsByTeam(@PathVariable("teamId") String teamId) {
+        List<SharedEmail> allEmails = sharedInboxService.getSharedEmailsByTeam(teamId);
+        return ResponseEntity.ok(allEmails);
+    }
+
+    @PostMapping("/share")
+    public ResponseEntity<Void> shareEmail(HttpServletRequest httpServletRequest,
+                                                  @RequestBody ShareEmailRequestDto shareEmailRequestDto) {
+        String sharedById = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
+        sharedInboxService.shareEmail(sharedById, shareEmailRequestDto);
+        return ResponseEntity.status(201).build();
+    }
+}

--- a/src/main/java/woozlabs/echo/domain/team/controller/TeamController.java
+++ b/src/main/java/woozlabs/echo/domain/team/controller/TeamController.java
@@ -31,7 +31,7 @@ public class TeamController {
                                            @RequestBody CreateTeamRequestDto createTeamRequestDto) {
         String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
         teamService.createTeam(uid, createTeamRequestDto);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(201).build();
     }
 
     @PostMapping("/team/{teamId}/invite")

--- a/src/main/java/woozlabs/echo/domain/team/dto/ShareEmailRequestDto.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/ShareEmailRequestDto.java
@@ -1,0 +1,11 @@
+package woozlabs.echo.domain.team.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ShareEmailRequestDto {
+
+    private String teamId;
+    private String threadId;
+    private String subject;
+}

--- a/src/main/java/woozlabs/echo/domain/team/dto/ShareEmailRequestDto.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/ShareEmailRequestDto.java
@@ -1,11 +1,15 @@
 package woozlabs.echo.domain.team.dto;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import woozlabs.echo.domain.team.dto.thread.ThreadGetResponse;
 
 @Getter
+@Setter
+@NoArgsConstructor
 public class ShareEmailRequestDto {
 
     private String teamId;
-    private String threadId;
-    private String subject;
+    private ThreadGetResponse gmailThread;
 }

--- a/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetBody.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetBody.java
@@ -1,0 +1,13 @@
+package woozlabs.echo.domain.team.dto.thread;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ThreadGetBody {
+
+    private String attachmentId;
+    private int size;
+    private String data;
+}

--- a/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetMessages.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetMessages.java
@@ -1,0 +1,29 @@
+package woozlabs.echo.domain.team.dto.thread;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import woozlabs.echo.domain.gmail.dto.thread.GmailThreadGetMessagesFrom;
+import woozlabs.echo.domain.gmail.dto.verification.ExtractVerificationInfo;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ThreadGetMessages {
+
+    private String id; // message id
+    private String date;
+    private String timezone; // timezone
+    private ThreadGetMessagesFrom from;
+    private List<ThreadGetMessagesCc> cc = new ArrayList<>();
+    private List<ThreadGetMessagesBcc> bcc = new ArrayList<>();
+    private List<ThreadGetMessagesTo> to = new ArrayList<>();
+    private String threadId; // thread id
+    private List<String> labelIds;
+    private String snippet;
+    private BigInteger historyId;
+    private ThreadGetPayload payload;
+    private ExtractVerificationInfo verification = new ExtractVerificationInfo();
+}

--- a/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetMessagesBcc.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetMessagesBcc.java
@@ -1,0 +1,12 @@
+package woozlabs.echo.domain.team.dto.thread;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ThreadGetMessagesBcc {
+
+    private String name;
+    private String email;
+}

--- a/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetMessagesCc.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetMessagesCc.java
@@ -1,0 +1,12 @@
+package woozlabs.echo.domain.team.dto.thread;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ThreadGetMessagesCc {
+
+    private String name;
+    private String email;
+}

--- a/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetMessagesFrom.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetMessagesFrom.java
@@ -1,0 +1,12 @@
+package woozlabs.echo.domain.team.dto.thread;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ThreadGetMessagesFrom {
+
+    private String name;
+    private String email;
+}

--- a/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetMessagesTo.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetMessagesTo.java
@@ -1,0 +1,12 @@
+package woozlabs.echo.domain.team.dto.thread;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ThreadGetMessagesTo {
+
+    private String name;
+    private String email;
+}

--- a/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetPart.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetPart.java
@@ -1,0 +1,15 @@
+package woozlabs.echo.domain.team.dto.thread;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ThreadGetPart {
+
+    private String partId;
+    private String mimeType;
+    private String fileName;
+    private ThreadGetBody body;
+    private List<ThreadGetPart> parts;
+}

--- a/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetPayload.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetPayload.java
@@ -1,0 +1,17 @@
+package woozlabs.echo.domain.team.dto.thread;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ThreadGetPayload {
+
+    private String partId;
+    private String mimeType;
+    private String fileName;
+    private ThreadGetBody body;
+    private List<ThreadGetPart> parts;
+}

--- a/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetResponse.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/thread/ThreadGetResponse.java
@@ -1,0 +1,16 @@
+package woozlabs.echo.domain.team.dto.thread;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigInteger;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ThreadGetResponse {
+
+    private String id;
+    private BigInteger historyId;
+    private List<ThreadGetMessages> messages;
+}

--- a/src/main/java/woozlabs/echo/domain/team/entity/SharedEmail.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/SharedEmail.java
@@ -3,12 +3,16 @@ package woozlabs.echo.domain.team.entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
-import lombok.Getter;
+import lombok.*;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Document(collection = "shared_emails")
 public class SharedEmail {
 

--- a/src/main/java/woozlabs/echo/domain/team/entity/SharedEmail.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/SharedEmail.java
@@ -1,8 +1,6 @@
 package woozlabs.echo.domain.team.entity;
 
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
 import lombok.*;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -18,10 +16,9 @@ public class SharedEmail {
 
     @Id
     private String id;
-    private String teamId;  // MySQL의 Team 엔티티 ID 참조
+    private String teamId;
     private String threadId;
-    private String subject;
-    private String sharedById;  // MySQL의 Member 엔티티 ID 참조
+    private String sharedById;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/woozlabs/echo/domain/team/entity/Thread.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/Thread.java
@@ -1,0 +1,27 @@
+package woozlabs.echo.domain.team.entity;
+
+import jakarta.persistence.Id;
+import lombok.*;
+import org.springframework.data.mongodb.core.mapping.Document;
+import woozlabs.echo.domain.gmail.dto.thread.GmailThreadGetMessages;
+import woozlabs.echo.domain.team.dto.thread.ThreadGetMessages;
+
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "threads")
+public class Thread {
+
+    @Id
+    private String id;
+    private BigInteger historyId;
+    private List<ThreadGetMessages> messages;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/woozlabs/echo/domain/team/repository/SharedInboxRepository.java
+++ b/src/main/java/woozlabs/echo/domain/team/repository/SharedInboxRepository.java
@@ -3,5 +3,9 @@ package woozlabs.echo.domain.team.repository;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import woozlabs.echo.domain.team.entity.SharedEmail;
 
-public interface SharedEmailRepository extends MongoRepository<SharedEmail, String> {
+import java.util.List;
+
+public interface SharedInboxRepository extends MongoRepository<SharedEmail, String> {
+
+    List<SharedEmail> findByTeamId(String teamId);
 }

--- a/src/main/java/woozlabs/echo/domain/team/repository/ThreadRepository.java
+++ b/src/main/java/woozlabs/echo/domain/team/repository/ThreadRepository.java
@@ -1,0 +1,7 @@
+package woozlabs.echo.domain.team.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import woozlabs.echo.domain.team.entity.Thread;
+
+public interface ThreadRepository extends MongoRepository<Thread, String> {
+}

--- a/src/main/java/woozlabs/echo/domain/team/service/SharedEmailService.java
+++ b/src/main/java/woozlabs/echo/domain/team/service/SharedEmailService.java
@@ -1,9 +1,0 @@
-package woozlabs.echo.domain.team.service;
-
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
-@Service
-@RequiredArgsConstructor
-public class SharedEmailService {
-}

--- a/src/main/java/woozlabs/echo/domain/team/service/SharedInboxService.java
+++ b/src/main/java/woozlabs/echo/domain/team/service/SharedInboxService.java
@@ -1,0 +1,34 @@
+package woozlabs.echo.domain.team.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import woozlabs.echo.domain.team.dto.ShareEmailRequestDto;
+import woozlabs.echo.domain.team.entity.SharedEmail;
+import woozlabs.echo.domain.team.repository.SharedInboxRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SharedInboxService {
+
+    private final SharedInboxRepository sharedInboxRepository;
+
+    public List<SharedEmail> getSharedEmailsByTeam(String teamId) {
+        return sharedInboxRepository.findByTeamId(teamId);
+    }
+
+    public void shareEmail(String sharedByUid, ShareEmailRequestDto shareEmailRequestDto) {
+        SharedEmail sharedEmail = SharedEmail.builder()
+                .teamId(shareEmailRequestDto.getTeamId())
+                .threadId(shareEmailRequestDto.getThreadId())
+                .subject(shareEmailRequestDto.getSubject())
+                .sharedById(sharedByUid)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        sharedInboxRepository.save(sharedEmail);
+    }
+}

--- a/src/main/java/woozlabs/echo/domain/team/service/SharedInboxService.java
+++ b/src/main/java/woozlabs/echo/domain/team/service/SharedInboxService.java
@@ -2,9 +2,12 @@ package woozlabs.echo.domain.team.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import woozlabs.echo.domain.gmail.dto.thread.GmailThreadGetResponse;
 import woozlabs.echo.domain.team.dto.ShareEmailRequestDto;
 import woozlabs.echo.domain.team.entity.SharedEmail;
+import woozlabs.echo.domain.team.entity.Thread;
 import woozlabs.echo.domain.team.repository.SharedInboxRepository;
+import woozlabs.echo.domain.team.repository.ThreadRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,16 +17,31 @@ import java.util.List;
 public class SharedInboxService {
 
     private final SharedInboxRepository sharedInboxRepository;
+    private final ThreadRepository threadRepository;
 
     public List<SharedEmail> getSharedEmailsByTeam(String teamId) {
         return sharedInboxRepository.findByTeamId(teamId);
     }
 
+    public Thread getSharedThread(String threadId) {
+        return threadRepository.findById(threadId).orElse(null);
+    }
+
     public void shareEmail(String sharedByUid, ShareEmailRequestDto shareEmailRequestDto) {
+
+        Thread thread = Thread.builder()
+                .id(shareEmailRequestDto.getGmailThread().getId())
+                .historyId(shareEmailRequestDto.getGmailThread().getHistoryId())
+                .messages(shareEmailRequestDto.getGmailThread().getMessages())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        Thread saveThread = threadRepository.save(thread);
+
         SharedEmail sharedEmail = SharedEmail.builder()
                 .teamId(shareEmailRequestDto.getTeamId())
-                .threadId(shareEmailRequestDto.getThreadId())
-                .subject(shareEmailRequestDto.getSubject())
+                .threadId(saveThread.getId())
                 .sharedById(sharedByUid)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())


### PR DESCRIPTION
## 설명
- close #112 
- Shared Email - Private Comments - 설계
    - 팀 구성:
        - 팀을 만들고 초대 링크를 통해 팀원 초대
    - 이메일 공유:
        - 팀원이 앱에서 특정 이메일을 보다가 '공유하기' 버튼을 클릭
        - 해당 이메일의 정보(스레드 ID, 제목 등)가 `SharedEmail` 테이블(MongoDB 컬렉션)에 저장
    - 데이터 저장:
        - `SharedEmail` 문서에는 공유된 이메일의 메타데이터(스레드 ID, 제목, 공유한 사람 등)가 저장
        - 실제 이메일 내용은 저장하지 않고, 스레드 ID를 이용해 원본 이메일을 참조
    - 공유된 이메일 접근:
        - 팀원들은 공유된 이메일 목록을 볼 수 있음
        - 특정 공유 이메일을 선택하면, 앱은 저장된 스레드 ID를 사용하여 원본 이메일 내용을 가져와 표시
    - 프라이빗 코멘트:
        - `PrivateComment` 컬렉션을 사용하여 공유된 이메일에 대한 팀 내부 코멘트를 저장
        - 각 코멘트는 특정 `SharedEmail`과 연결되어 있음
    - 딥링크:
        - 각 `SharedEmail`에 대한 고유 URL을 생성하여 팀 내에서 쉽게 공유할 수 있도록

## 완료한 기능 명세
- [x] 공유하기 버튼을 클릭했을 때를 위한 공유 API (공유할 메일의 제목도 필요함, teamId, threadId, subject)
- [x] MongoDB에서 공유하기를 통해 기록된 메일의 정보 불러오기 API
- [x] 팀 내부 공유메일 인박스에 등록된 공유메일 리스트들의 threadId를 통해 해당 메일 반환하는 API

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기

### Mongo Thread 공유
<img width="789" alt="image" src="https://github.com/user-attachments/assets/24ff5bc8-d079-429d-a41c-147c8a215ba0">

### Mongo Thread 불러오기
<img width="809" alt="image" src="https://github.com/user-attachments/assets/4ef00b5c-93f2-4f03-ad41-57eca306e3af">

### Mongo 팀내 공유 Thread 목록 불러오기
<img width="828" alt="image" src="https://github.com/user-attachments/assets/784d4d0b-155d-4d86-80e5-30a7cfab9cad">


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

