### PR TITLE
[FEAT] 팀내 기능에 따른 기능 접근 제어 #1

### DIFF
--- a/src/main/java/woozlabs/echo/domain/team/controller/SharedInboxController.java
+++ b/src/main/java/woozlabs/echo/domain/team/controller/SharedInboxController.java
@@ -20,14 +20,18 @@ public class SharedInboxController {
     private final SharedInboxService sharedInboxService;
 
     @GetMapping("/emails/team/{teamId}")
-    public ResponseEntity<List<SharedEmail>> getSharedEmailsByTeam(@PathVariable("teamId") String teamId) {
-        List<SharedEmail> allEmails = sharedInboxService.getSharedEmailsByTeam(teamId);
+    public ResponseEntity<List<SharedEmail>> getSharedEmailsByTeam(HttpServletRequest httpServletRequest,
+                                                                   @PathVariable("teamId") String teamId) {
+        String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
+        List<SharedEmail> allEmails = sharedInboxService.getSharedEmailsByTeam(uid, teamId);
         return ResponseEntity.ok(allEmails);
     }
 
     @GetMapping("/thread/{threadId}")
-    public ResponseEntity<Thread> getSharedThread(@PathVariable("threadId") String threadId) {
-        Thread thread = sharedInboxService.getSharedThread(threadId);
+    public ResponseEntity<Thread> getSharedThread(HttpServletRequest httpServletRequest,
+                                                  @PathVariable("threadId") String threadId) {
+        String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);
+        Thread thread = sharedInboxService.getSharedThread(uid, threadId);
         if (thread == null) {
             return ResponseEntity.notFound().build();
         }

--- a/src/main/java/woozlabs/echo/domain/team/controller/TeamController.java
+++ b/src/main/java/woozlabs/echo/domain/team/controller/TeamController.java
@@ -43,7 +43,7 @@ public class TeamController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/invite/accept")
+    @PostMapping("/team/invite/accept")
     public ResponseEntity<Void> acceptInvitation(HttpServletRequest httpServletRequest,
                                                  @RequestParam String token) {
         String uid = (String) httpServletRequest.getAttribute(GlobalConstant.FIREBASE_UID_KEY);

--- a/src/main/java/woozlabs/echo/domain/team/entity/Role.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/Role.java
@@ -1,6 +1,8 @@
 package woozlabs.echo.domain.team.entity;
 
 public enum Role {
-
-    ADMIN, EDITOR, VIEWER
+    ADMIN,
+    EDITOR,
+    VIEWER,
+    PUBLIC_VIEWER
 }

--- a/src/main/java/woozlabs/echo/domain/team/entity/ShareStatus.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/ShareStatus.java
@@ -1,0 +1,7 @@
+package woozlabs.echo.domain.team.entity;
+
+public enum ShareStatus {
+    PRIVATE,
+    TEAM,
+    PUBLIC
+}

--- a/src/main/java/woozlabs/echo/domain/team/entity/SharedEmail.java
+++ b/src/main/java/woozlabs/echo/domain/team/entity/SharedEmail.java
@@ -19,6 +19,7 @@ public class SharedEmail {
     private String teamId;
     private String threadId;
     private String sharedById;
+    private ShareStatus shareStatus;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/woozlabs/echo/domain/team/repository/SharedInboxRepository.java
+++ b/src/main/java/woozlabs/echo/domain/team/repository/SharedInboxRepository.java
@@ -4,8 +4,11 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import woozlabs.echo.domain.team.entity.SharedEmail;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SharedInboxRepository extends MongoRepository<SharedEmail, String> {
 
     List<SharedEmail> findByTeamId(String teamId);
+
+    Optional<SharedEmail> findByThreadId(String threadId);
 }

--- a/src/main/java/woozlabs/echo/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/woozlabs/echo/domain/team/repository/TeamMemberRepository.java
@@ -1,0 +1,12 @@
+package woozlabs.echo.domain.team.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import woozlabs.echo.domain.member.entity.Member;
+import woozlabs.echo.domain.team.entity.TeamMember;
+
+import java.util.Optional;
+
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+
+    Optional<TeamMember> findByMemberAndTeamId(Member member, Long teamId);
+}

--- a/src/main/java/woozlabs/echo/domain/team/service/SharedInboxService.java
+++ b/src/main/java/woozlabs/echo/domain/team/service/SharedInboxService.java
@@ -2,32 +2,54 @@ package woozlabs.echo.domain.team.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import woozlabs.echo.domain.gmail.dto.thread.GmailThreadGetResponse;
 import woozlabs.echo.domain.team.dto.ShareEmailRequestDto;
 import woozlabs.echo.domain.team.entity.SharedEmail;
+import woozlabs.echo.domain.team.entity.TeamMember;
 import woozlabs.echo.domain.team.entity.Thread;
 import woozlabs.echo.domain.team.repository.SharedInboxRepository;
 import woozlabs.echo.domain.team.repository.ThreadRepository;
+import woozlabs.echo.domain.team.utils.AuthorizationUtil;
+import woozlabs.echo.global.exception.CustomErrorException;
+import woozlabs.echo.global.exception.ErrorCode;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class SharedInboxService {
 
     private final SharedInboxRepository sharedInboxRepository;
     private final ThreadRepository threadRepository;
+    private final TeamService teamService;
 
-    public List<SharedEmail> getSharedEmailsByTeam(String teamId) {
+    public List<SharedEmail> getSharedEmailsByTeam(String uid, String teamId) {
+        teamService.getTeamMember(uid, Long.parseLong(teamId));
         return sharedInboxRepository.findByTeamId(teamId);
     }
 
-    public Thread getSharedThread(String threadId) {
+    public Thread getSharedThread(String uid, String threadId) {
+        SharedEmail sharedEmail = sharedInboxRepository.findByThreadId(threadId)
+                .orElseThrow(() -> new CustomErrorException(ErrorCode.NOT_FOUND_SHARED_EMAIL));
+
+        TeamMember teamMember =  teamService.getTeamMember(uid, Long.parseLong(sharedEmail.getTeamId()));
+        if (!AuthorizationUtil.canViewSharedEmail(teamMember, sharedEmail.getShareStatus())) {
+            throw new CustomErrorException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
         return threadRepository.findById(threadId).orElse(null);
     }
 
+    @Transactional
     public void shareEmail(String sharedByUid, ShareEmailRequestDto shareEmailRequestDto) {
+        TeamMember teamMember = teamService.getTeamMember(sharedByUid, Long.parseLong(shareEmailRequestDto.getTeamId()));
+        if (!AuthorizationUtil.canEditSharedEmail(teamMember)) {
+            throw new CustomErrorException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
 
         Thread thread = Thread.builder()
                 .id(shareEmailRequestDto.getGmailThread().getId())

--- a/src/main/java/woozlabs/echo/domain/team/service/TeamService.java
+++ b/src/main/java/woozlabs/echo/domain/team/service/TeamService.java
@@ -14,6 +14,7 @@ import woozlabs.echo.domain.team.entity.Team;
 import woozlabs.echo.domain.team.entity.TeamInvitation;
 import woozlabs.echo.domain.team.entity.TeamMember;
 import woozlabs.echo.domain.team.repository.TeamInvitationRepository;
+import woozlabs.echo.domain.team.repository.TeamMemberRepository;
 import woozlabs.echo.domain.team.repository.TeamRepository;
 import woozlabs.echo.global.constant.GlobalConstant;
 import woozlabs.echo.global.exception.CustomErrorException;
@@ -32,6 +33,7 @@ public class TeamService {
     private final TeamRepository teamRepository;
     private final MemberRepository memberRepository;
     private final TeamInvitationRepository teamInvitationRepository;
+    private final TeamMemberRepository teamMemberRepository;
     private final EmailService emailService;
 
     public List<TeamResponseDto> getTeams(String uid) {
@@ -40,6 +42,14 @@ public class TeamService {
         return teams.stream()
                 .map(TeamResponseDto::new)
                 .collect(Collectors.toList());
+    }
+
+    public TeamMember getTeamMember(String uid, Long teamId) {
+        Member member = memberRepository.findByUid(uid)
+                .orElseThrow(() -> new CustomErrorException(ErrorCode.NOT_FOUND_MEMBER_ERROR_MESSAGE));
+
+        return teamMemberRepository.findByMemberAndTeamId(member, teamId)
+                .orElseThrow(() -> new CustomErrorException(ErrorCode.NOT_FOUND_TEAM_MEMBER));
     }
 
     @Transactional

--- a/src/main/java/woozlabs/echo/domain/team/utils/AuthorizationUtil.java
+++ b/src/main/java/woozlabs/echo/domain/team/utils/AuthorizationUtil.java
@@ -1,0 +1,27 @@
+package woozlabs.echo.domain.team.utils;
+
+import woozlabs.echo.domain.team.entity.Role;
+import woozlabs.echo.domain.team.entity.ShareStatus;
+import woozlabs.echo.domain.team.entity.TeamMember;
+
+public class AuthorizationUtil {
+
+    public static boolean canViewSharedEmail(TeamMember teamMember, ShareStatus shareStatus) {
+        if (teamMember == null) {
+            return shareStatus == ShareStatus.PUBLIC;
+        }
+
+        Role role = teamMember.getRole();
+        return role == Role.ADMIN || role == Role.EDITOR ||
+                (role == Role.VIEWER && (shareStatus == ShareStatus.PUBLIC || shareStatus == ShareStatus.TEAM)) ||
+                (role == Role.PUBLIC_VIEWER && shareStatus == ShareStatus.PUBLIC);
+    }
+
+    public static boolean canEditSharedEmail(TeamMember teamMember) {
+        return teamMember != null && (teamMember.getRole() == Role.ADMIN || teamMember.getRole() == Role.EDITOR);
+    }
+
+    public static boolean canDeleteSharedEmail(TeamMember teamMember) {
+        return teamMember != null && (teamMember.getRole() == Role.ADMIN || teamMember.getRole() == Role.EDITOR);
+    }
+}

--- a/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
+++ b/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
@@ -83,6 +83,9 @@ public enum ErrorCode {
     FAILED_TO_INVITATION_MAIL(500, "Failed to send email"),
     NOT_FOUND_INVITATION_TOKEN(404, "Not Found: Invitation Token"),
     INVITATION_EXPIRED(400, "The team invitation approval deadline has expired"),
+    NOT_FOUND_TEAM_MEMBER(404, "The Member can't be found in the team"),
+    NOT_FOUND_SHARED_EMAIL(404, "Not Found: Shared Email"),
+    UNAUTHORIZED_ACCESS(401, "You can't access this feature with this privilege"),
 
     // verification
     KEYWORD_IO_EXCEPTION(500, "I/O Exception finding verification keywords"),


### PR DESCRIPTION
## 설명
- close #124 
- 메일을 공유하거나 작업할 때 권한에 따라 작업 유무를 분리해야합니다.
- ADMIN: 팀원 추가/제거, 권한 관리, 이메일 삭제 및 발송 가능
- EDITOR: 초안 편집 및 발송, 이메일 삭제 가능
- VIEWER: 이메일 및 초안 조회만 가능
- 외부인을 위한 PUBLIC_VIEWER role도 추가합니다.

1. uid를 통해 해당 멤버를 찾은 후 그 멤버가 해당 Team에 속해있는지 확인합니다.
2. 이후 TeamMember로 해당 멤버를 불러옵니다.
3. TeamMember로 그 멤버의 팀내 역할(권한)을 찾고 해당 공유 메일의 상태와 비교합니다.
4. Util 클래스를 통해 해당 멤버의 권한이 그 기능에 대해 접근할 수 있는지 판별합니다.

## 완료한 기능 명세
- [x] 공유 이메일에 Status 추가(PRIVATE, TEAM, PUBLIC)
- [x] Role에 PUBLIC_VIEWER 추가
- [x] 권한에 따른 기능 제어 Util
- [x] uid를 통한 해당 멤버를 팀내에서 찾는 getTeamMember 작성
- [x] 팀내 공유 쓰레드 불러오기, 쓰레드 공유하기에 권한에 따른 처리

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

