### PR TITLE
[REFACTOR] AWS SES 속도 검증, 테스트 코드 및 flyway DB Migration 적용 및 잡무

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,14 @@ dependencies {
 	implementation group: 'com.google.firebase', name: 'firebase-admin', version: '9.3.0'
 	implementation 'org.jsoup:jsoup:1.15.3'
 	implementation 'com.amazonaws:aws-java-sdk-ses:1.12.429'
+
 	// test dl
 	implementation 'com.squareup.okhttp3:okhttp:4.9.3'
 	implementation 'com.google.code.gson:gson:2.8.8'
+
+	// db
+	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.flywaydb:flyway-mysql'
 }
 
 tasks.named('test') {

--- a/src/main/java/woozlabs/echo/domain/member/controller/MemberController.java
+++ b/src/main/java/woozlabs/echo/domain/member/controller/MemberController.java
@@ -4,10 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import woozlabs.echo.domain.member.dto.MemberDto;
 import woozlabs.echo.domain.member.dto.ProfileResponseDto;
 import woozlabs.echo.domain.member.service.MemberService;
@@ -22,7 +19,13 @@ public class MemberController {
 
     @GetMapping("/profile")
     public ResponseEntity<ProfileResponseDto> getProfileByEmail(@RequestParam String email) {
-        ProfileResponseDto response = memberService.getProfileByEmail(email);
+        ProfileResponseDto response = memberService.getProfileByField("email", email);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{uid}/profile")
+    public ResponseEntity<ProfileResponseDto> getProfileByUid(@PathVariable("uid") String uid) {
+        ProfileResponseDto response = memberService.getProfileByField("uid", uid);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/woozlabs/echo/domain/member/service/MemberService.java
+++ b/src/main/java/woozlabs/echo/domain/member/service/MemberService.java
@@ -9,7 +9,6 @@ import woozlabs.echo.domain.member.dto.ProfileResponseDto;
 import woozlabs.echo.domain.member.entity.Member;
 import woozlabs.echo.domain.member.entity.SuperAccount;
 import woozlabs.echo.domain.member.repository.MemberRepository;
-import woozlabs.echo.domain.member.repository.SuperAccountRepository;
 import woozlabs.echo.global.exception.CustomErrorException;
 import woozlabs.echo.global.exception.ErrorCode;
 
@@ -22,11 +21,19 @@ import java.util.stream.Collectors;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final SuperAccountRepository superAccountRepository;
 
-    public ProfileResponseDto getProfileByEmail(String email) {
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new CustomErrorException(ErrorCode.NOT_FOUND_MEMBER_ERROR_MESSAGE));
+    public ProfileResponseDto getProfileByField(String fieldType, String fieldValue) {
+        Member member;
+
+        if (fieldType.equals("email")) {
+            member = memberRepository.findByEmail(fieldValue)
+                    .orElseThrow(() -> new CustomErrorException(ErrorCode.NOT_FOUND_MEMBER_ERROR_MESSAGE));
+        } else if (fieldType.equals("uid")) {
+            member = memberRepository.findByUid(fieldValue)
+                    .orElseThrow(() -> new CustomErrorException(ErrorCode.NOT_FOUND_MEMBER_ERROR_MESSAGE));
+        } else {
+            throw new CustomErrorException(ErrorCode.INVALID_FIELD_TYPE_ERROR_MESSAGE);
+        }
 
         return ProfileResponseDto.builder()
                 .displayName(member.getDisplayName())

--- a/src/main/java/woozlabs/echo/domain/team/dto/TeamInvitationRequestDto.java
+++ b/src/main/java/woozlabs/echo/domain/team/dto/TeamInvitationRequestDto.java
@@ -1,9 +1,11 @@
 package woozlabs.echo.domain.team.dto;
 
 import lombok.Getter;
+import lombok.Setter;
 import woozlabs.echo.domain.team.entity.TeamMemberRole;
 
 @Getter
+@Setter
 public class TeamInvitationRequestDto {
 
     private String inviteeEmail;

--- a/src/main/java/woozlabs/echo/global/config/AsyncConfig.java
+++ b/src/main/java/woozlabs/echo/global/config/AsyncConfig.java
@@ -13,9 +13,9 @@ public class AsyncConfig {
     @Bean(name = "threadPoolTaskExecutor")
     public Executor threadPoolTaskExecutor(){
         ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
-        taskExecutor.setCorePoolSize(50);
-        taskExecutor.setMaxPoolSize(200);
-        taskExecutor.setQueueCapacity(100);
+        taskExecutor.setCorePoolSize(10);
+        taskExecutor.setMaxPoolSize(50);
+        taskExecutor.setQueueCapacity(50);
         return taskExecutor;
     }
 }

--- a/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
+++ b/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     FAILED_TO_REDIRECT_GOOGLE_USER_INFO(500, "Failed to redirect Google user info"),
     FAILED_TO_REFRESH_GOOGLE_TOKEN(500, "Failed to refresh google token"),
     FAILED_TO_FETCH_GOOGLE_TOKENS(500, "Failed to get Google access tokens"),
+    INVALID_FIELD_TYPE_ERROR_MESSAGE(400, "Invalid Member Field Type"),
 
     // token
     NOT_FOUND_ACCESS_TOKEN(404, "Not found: Access Token"),

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,167 @@
+-- Contact Group
+CREATE TABLE IF NOT EXISTS `contact_group` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `created_at` DATETIME(6),
+    `updated_at` DATETIME(6),
+    `owner_id` BIGINT,
+    `name` VARCHAR(255),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`owner_id`) REFERENCES `member` (`id`)
+    ) ENGINE=InnoDB;
+
+-- Contact Group Emails
+CREATE TABLE IF NOT EXISTS `contact_group_emails` (
+    `contact_group_id` BIGINT NOT NULL,
+    `email` VARCHAR(255),
+    PRIMARY KEY (`contact_group_id`, `email`),
+    FOREIGN KEY (`contact_group_id`) REFERENCES `contact_group` (`id`)
+    ) ENGINE=InnoDB;
+
+-- Email Recipient
+CREATE TABLE IF NOT EXISTS `email_recipient` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `email_template_id` BIGINT,
+    `email` VARCHAR(255),
+    `type` ENUM('BCC','CC','TO'),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`email_template_id`) REFERENCES `email_template` (`id`)
+    ) ENGINE=InnoDB;
+
+-- Email Template
+CREATE TABLE IF NOT EXISTS `email_template` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `member_id` BIGINT,
+    `body` TEXT,
+    `subject` VARCHAR(255),
+    `template_name` VARCHAR(255),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`member_id`) REFERENCES `member` (`id`)
+    ) ENGINE=InnoDB;
+
+-- FCM Token
+CREATE TABLE IF NOT EXISTS `fcm_token` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `member_id` BIGINT,
+    `fcm_token` VARCHAR(255),
+    `machine_uuid` VARCHAR(255),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`member_id`) REFERENCES `member` (`id`)
+    ) ENGINE=InnoDB;
+
+-- Member
+CREATE TABLE IF NOT EXISTS `member` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `is_primary` BIT NOT NULL,
+    `access_token_fetched_at` DATETIME(6),
+    `created_at` DATETIME(6),
+    `updated_at` DATETIME(6),
+    `super_account_id` BIGINT,
+    `access_token` VARCHAR(255),
+    `display_name` VARCHAR(255),
+    `email` VARCHAR(255),
+    `google_provider_id` VARCHAR(255),
+    `profile_image_url` VARCHAR(255),
+    `refresh_token` VARCHAR(255),
+    `uid` VARCHAR(255),
+    `role` ENUM('ROLE_ADMIN','ROLE_USER'),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`super_account_id`) REFERENCES `super_account` (`id`)
+    ) ENGINE=InnoDB;
+
+-- Member Contact Group
+CREATE TABLE IF NOT EXISTS `member_contact_group` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `contact_group_id` BIGINT,
+    `member_id` BIGINT,
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`contact_group_id`) REFERENCES `contact_group` (`id`),
+    FOREIGN KEY (`member_id`) REFERENCES `member` (`id`)
+    ) ENGINE=InnoDB;
+
+-- Pub Sub History
+CREATE TABLE IF NOT EXISTS `pub_sub_history` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `history_id` DECIMAL(38,0),
+    `member_id` BIGINT,
+    PRIMARY KEY (`id`),
+    UNIQUE (`member_id`),
+    FOREIGN KEY (`member_id`) REFERENCES `member` (`id`) ON DELETE CASCADE
+    ) ENGINE=InnoDB;
+
+-- Signature
+CREATE TABLE IF NOT EXISTS `signature` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `created_at` DATETIME(6),
+    `updated_at` DATETIME(6),
+    `owner_id` BIGINT,
+    `name` VARCHAR(255),
+    `content` TINYTEXT,
+    `type` ENUM('MEMBER','TEAM'),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`owner_id`) REFERENCES `member` (`id`)
+    ) ENGINE=InnoDB;
+
+-- Super Account
+CREATE TABLE IF NOT EXISTS `super_account` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `created_at` DATETIME(6),
+    `updated_at` DATETIME(6),
+    PRIMARY KEY (`id`)
+    ) ENGINE=InnoDB;
+
+-- Super Account Member UIDs
+CREATE TABLE IF NOT EXISTS `super_account_member_uids` (
+    `super_account_id` BIGINT NOT NULL,
+    `member_uid` VARCHAR(255),
+    PRIMARY KEY (`super_account_id`, `member_uid`),
+    FOREIGN KEY (`super_account_id`) REFERENCES `super_account` (`id`)
+    ) ENGINE=InnoDB;
+
+-- Team
+CREATE TABLE IF NOT EXISTS `team` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `created_at` DATETIME(6),
+    `updated_at` DATETIME(6),
+    `creator_id` BIGINT,
+    `name` VARCHAR(255),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`creator_id`) REFERENCES `member` (`id`)
+    ) ENGINE=InnoDB;
+
+-- Team Invitation
+CREATE TABLE IF NOT EXISTS `team_invitation` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `deleted` BIT NOT NULL,
+    `expires_at` DATETIME(6),
+    `sent_at` DATETIME(6),
+    `inviter_id` BIGINT,
+    `team_id` BIGINT,
+    `invitee_email` VARCHAR(255),
+    `token` VARCHAR(255),
+    `role` ENUM('ADMIN','EDITOR','PUBLIC_VIEWER','VIEWER'),
+    `status` ENUM('ACCEPTED','EXPIRED','PENDING','REJECTED'),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`inviter_id`) REFERENCES `member` (`id`),
+    FOREIGN KEY (`team_id`) REFERENCES `team` (`id`)
+    ) ENGINE=InnoDB;
+
+-- Team Member
+CREATE TABLE IF NOT EXISTS `team_member` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `member_id` BIGINT,
+    `team_id` BIGINT,
+    `role` ENUM('ADMIN','EDITOR','PUBLIC_VIEWER','VIEWER'),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`member_id`) REFERENCES `member` (`id`),
+    FOREIGN KEY (`team_id`) REFERENCES `team` (`id`)
+    ) ENGINE=InnoDB;
+
+-- User Sidebar Config
+CREATE TABLE IF NOT EXISTS `user_sidebar_config` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `member_id` BIGINT,
+    `sidebar_config` TEXT,
+    PRIMARY KEY (`id`),
+    UNIQUE (`member_id`),
+    FOREIGN KEY (`member_id`) REFERENCES `member` (`id`)
+    ) ENGINE=InnoDB;

--- a/src/test/java/woozlabs/echo/domain/team/service/EmailServiceTest.java
+++ b/src/test/java/woozlabs/echo/domain/team/service/EmailServiceTest.java
@@ -1,0 +1,82 @@
+package woozlabs.echo.domain.team.service;
+
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
+import com.amazonaws.services.simpleemail.model.SendEmailRequest;
+import com.amazonaws.services.simpleemail.model.SendEmailResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.thymeleaf.TemplateEngine;
+import woozlabs.echo.domain.team.dto.SendInvitationEmailDto;
+import woozlabs.echo.domain.team.entity.TeamMemberRole;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+
+    @InjectMocks
+    private EmailService emailService;
+
+    @Mock
+    private AmazonSimpleEmailService amazonSimpleEmailService;
+
+    @Mock
+    private TemplateEngine templateEngine;
+
+    private SendInvitationEmailDto sendInvitationEmailDto;
+
+    @BeforeEach
+    void setUp() {
+        sendInvitationEmailDto = SendInvitationEmailDto.builder()
+                .to("echo@example.com")
+                .username("echo")
+                .userImage("https://vercel.com/static/vercel-user.png")
+                .invitedByUsername("Admin")
+                .invitedByEmail("jh07050@gmail.com")
+                .teamName("woozlabs")
+                .teamTeamMemberRole(TeamMemberRole.ADMIN)
+                .teamImage("https://vercel.com/static/vercel-team.png")
+                .inviteLink("https://example.com/invite")
+                .build();
+
+        when(templateEngine.process(anyString(), any())).thenReturn("<html>Mocked HTML content</html>");
+    }
+
+    @Test
+    @DisplayName("AWS SES를 통해 팀 초대 메일을 발송합니다.")
+    void sendEmailViaSES() throws Exception {
+        // given
+        SendEmailResult sendEmailResult = new SendEmailResult();
+        when(amazonSimpleEmailService.sendEmail(any(SendEmailRequest.class))).thenReturn(sendEmailResult);
+
+        long startTime = System.currentTimeMillis();
+
+        // when
+        emailService.sendEmailViaSES(sendInvitationEmailDto);
+
+        long endTime = System.currentTimeMillis();
+        long duration = endTime - startTime;
+
+        // then
+        System.out.println("SES Email Send Duration: " + duration + " ms");
+
+        // 검증
+        ArgumentCaptor<SendEmailRequest> captor = ArgumentCaptor.forClass(SendEmailRequest.class);
+        verify(amazonSimpleEmailService, times(1)).sendEmail(captor.capture());
+        SendEmailRequest capturedRequest = captor.getValue();
+
+        assertNotNull(capturedRequest, "SendEmailRequest should not be null");
+        assertEquals("echo@example.com", capturedRequest.getDestination().getToAddresses().get(0));
+        assertEquals("Join your team on Echo", capturedRequest.getMessage().getSubject().getData());
+    }
+}


### PR DESCRIPTION
## 설명
- 추후 프로덕션 환경을 위해서 DB 형상 관리를 위한 flyway를 추가합니다.
- flyway에 V1__init을 넣어두고 커밋메세지는 어제 날짜인 240823으로 해두었는데 프로덕션 직전의 엔티티 구조에 맞춰서 설정해둔 후
  프로덕션 환경에서는 `ddl-auto`를 `valid`로 설정하면 됩니다.
- SES 검증을 할겸 속도비교를 위해 다시 코드를 확인하고 테스트코드를 작성했는데 예상한 속도와 달라서 테스트코드 재작성이 필요해보입니다.
  - 테스트 환경에서 비동기가 어떻게 돌아가는지와 조금의 학습 및 구현이 필요합니다.
- 내일 이사 후 계정 추가에 대해서 설계할 예정입니다.

## 완료한 기능 명세
- [x] flyway setting
  - [x] 240823.version DB 엔티티 형상 기록
- [x] AWS SES 테스트코드
  - [x] 학습 정리

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

