### PR TITLE
[Feat]: Billing 관련 이메일 필터링 기능 구현

### DIFF
--- a/src/main/java/woozlabs/echo/domain/gmail/controller/PubSubController.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/controller/PubSubController.java
@@ -33,6 +33,7 @@ public class PubSubController {
             pubSubService.handleFirebaseCloudMessage(pubsubMessage);
             return new ResponseEntity<>(HttpStatus.OK);
         } catch (Exception e){
+            log.error(e.getMessage()); // checking bug
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/woozlabs/echo/domain/gmail/service/PubSubService.java
+++ b/src/main/java/woozlabs/echo/domain/gmail/service/PubSubService.java
@@ -73,15 +73,14 @@ public class PubSubService {
         String email = notification.getEmailAddress();
         int deliveryAttempt = pubsubMessage.getDeliveryAttempt();
         log.info(String.valueOf(deliveryAttempt));
+        if(deliveryAttempt > 2){ // stop pub/sub alert(* case: failed to alert more than three times)
+            log.info("Exceed delivery attempt limit");
+            return;
+        }
         BigInteger newHistoryId = new BigInteger(notification.getHistoryId());
         Account account = accountRepository.findByEmail(email).orElseThrow(
                 () -> new CustomErrorException(ErrorCode.NOT_FOUND_ACCOUNT_ERROR_MESSAGE, ErrorCode.NOT_FOUND_ACCOUNT_ERROR_MESSAGE.getMessage())
         );
-        if(deliveryAttempt > 2){ // stop pub/sub alert(* case: failed to alert more than three times)
-            log.info("Request to stop pub/sub alert");
-            gmailServiceImpl.stopPubSub(account.getUid());
-            return;
-        }
         PubSubHistory pubSubHistory = pubSubHistoryRepository.findByAccount(account).orElseThrow(
                 () -> new CustomErrorException(ErrorCode.NOT_FOUND_PUB_SUB_HISTORY_ERR, ErrorCode.NOT_FOUND_PUB_SUB_HISTORY_ERR.getMessage())
         );

--- a/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
+++ b/src/main/java/woozlabs/echo/global/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
     INVALID_ACCESS_TOKEN(401, "Invalid Access Token"),
     TOO_MANY_REQUESTS(429, "Too many requests"),
     INVALID_NEXT_PAGE_TOKEN(400, "Invalid next page token"),
+    BILLING_ERROR_MESSAGE(402, "Payment Required"),
 
     // calendar
     GOOGLE_CALENDAR_SECURITY_ERROR(500, "Security error while fetching Google Calendar events"),

--- a/src/main/java/woozlabs/echo/global/utils/GlobalUtility.java
+++ b/src/main/java/woozlabs/echo/global/utils/GlobalUtility.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 public class GlobalUtility {
     public static List<String> splitSenderData(String sender){
         List<String> splitSender = new ArrayList<>();
-        String replaceSender = sender.replace("\"", "");
+        String replaceSender = sender.replaceAll("\"", "");
         String regex = "(.*)\\s*<(.*)>";
         Pattern pattern = Pattern.compile(regex);
         Matcher matcher = pattern.matcher(replaceSender);


### PR DESCRIPTION
### PR 메시지 
 1. 제목: [Feat]: Billing 관련 이메일 필터링 기능 구현
 2. 내용: Billing 관련 이메일 필터링 기능 구현. 이후에 도입될 빌링 기능에 대해 결제를 하지 않았을 경우 메일의 일부 데이터만 전달하도록 기능을 구현해야 했다.

## 설명
- 결제를 하지 않았을 경우
  - 사이드 바에 존재하는 쿼리를 날렸을 경우 60일 이전 데이터까지만 전송하도록 "after: 현재 날짜 기준 60일 이전 날짜" 쿼리를 추가하였음.
  - 만약 검색을 통해 복합 쿼리를 날렸을 경우 일단 스레드 데이터를 가져온 후 가장 첫 데이터가 60일보다 더 이전의 메일이면 402 상태코드와 함께 에러를 반환하도록 하였음. 
- 결제를 하였을 경우
  - 기존과 그대로 데이터 반환
 
## 완료한 기능 명세
- [x] Billing 관련 에러 처리
- [x] Billing 기준 스레드 필터링 기능 구현
- [ ] 요청 헤더로부터 요청 날짜 파싱 기능 구현

### 스크린샷
- 빌링 관련 에러 처리
![image](https://github.com/user-attachments/assets/5d9e5948-6bdb-4723-99f5-f1f674c7e908)


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

